### PR TITLE
Update generator and fix typos

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -32,7 +32,6 @@ subPackage {
 	dependency "asdf" version="~>0.7.15"
 	targetType "executable"
 	targetName "generator"
-    targetPath "bin/"
 	dflags "--link-internally" platform="windows-ldc"
 	sourcePaths "modules/tools/generator"
 }

--- a/modules/tools/generator/api.d
+++ b/modules/tools/generator/api.d
@@ -254,14 +254,14 @@ void writeStructs(ref ExtensionsApi api, string dirPath) {
     string buf;
     auto s = appender(buf);
     s ~= "module godot.structs;\n\n";
-    s ~= "import godot;\n";
-    s ~= "import godot.abi;\n\n";
+    s ~= "public import godot;\n";
+    s ~= "public import godot.abi;\n\n";
 
     foreach (st; api.native_structures) {
         auto source = st.parseMembers();
 
         foreach (imp; st.used_classes)
-            s ~= "import godot." ~ imp.asModuleName ~ ";\n";
+            s ~= "public import godot." ~ imp.asModuleName ~ ";\n";
 
         s ~= "struct " ~ st.name.dType ~ " {\n";
 

--- a/modules/tools/generator/c.d
+++ b/modules/tools/generator/c.d
@@ -42,13 +42,13 @@ struct Api {
 
     string source() {
         string ret = "module godot.abi.api;\n\n";
-        ret ~= "import godot.abi.core;\n\n";
+        ret ~= "public import godot.abi.core;\n\n";
         foreach (v; extensions)
-            ret ~= "import godot.abi." ~ v.name ~ ";\n";
+            ret ~= "public import godot.abi." ~ v.name ~ ";\n";
 
-        ret ~= "import std.meta : AliasSeq, staticIndexOf;\n";
-        ret ~= "import std.format : format;\nimport std.string : capitalize, toLower;\nimport std.conv : text;\n";
-        ret ~= "import core.stdc.stdint;\nimport core.stdc.stddef : wchar_t;\n\n";
+        ret ~= "public import std.meta : AliasSeq, staticIndexOf;\n";
+        ret ~= "public import std.format : format;\nimport std.string : capitalize, toLower;\nimport std.conv : text;\n";
+        ret ~= "public import core.stdc.stdint;\nimport core.stdc.stddef : wchar_t;\n\n";
 
         ret ~= q{
 			extern(C) struct godot_gdextension_api_version

--- a/modules/tools/generator/d.d
+++ b/modules/tools/generator/d.d
@@ -76,19 +76,19 @@ string[2] generateClass(GodotClass c) {
     ret ~= "module godot.";
     ret ~= c.name.asModuleName;
     ret ~= ";\n";
-    ret ~= "import std.meta : AliasSeq, staticIndexOf;\n";
-    ret ~= "import std.traits : Unqual;\n";
-    ret ~= "import godot.api.traits;\nimport godot;\nimport godot.abi;\n";
-    ret ~= "import godot.api.bind;\n";
-    ret ~= "import godot.api.reference;\n";
-    ret ~= "import godot.globalenums;\n";
+    ret ~= "public import std.meta : AliasSeq, staticIndexOf;\n";
+    ret ~= "public import std.traits : Unqual;\n";
+    ret ~= "public import godot.api.traits;\nimport godot;\nimport godot.abi;\n";
+    ret ~= "public import godot.api.bind;\n";
+    ret ~= "public import godot.api.reference;\n";
+    ret ~= "public import godot.globalenums;\n";
 
     if (c.name.godotType != "Object") {
-        ret ~= "import godot.object;\n";
+        ret ~= "public import godot.object;\n";
     }
 
     if (c.instanciable) {
-        ret ~= "import godot.classdb;\n";
+        ret ~= "public import godot.classdb;\n";
     }
 
     ret ~= c.source;

--- a/src/godot/api/register.d
+++ b/src/godot/api/register.d
@@ -292,7 +292,7 @@ void register(T)(GDExtensionClassLibraryPtr lib) if (is(T == class)) {
         static if (__traits(compiles, __traits(getMember, T, "_ready"))) {
             //if (MethodWrapper!(T, __traits(getMember, T, "_ready")).funName == p_name) {
             if (str == "_ready") {
-                return cast(GDExtensionExtensionClassCallVirtual) 
+                return cast(GDExtensionClassCallVirtual) 
                     &OnReadyWrapper!(T, __traits(getMember, T, "_ready")).callOnReady;
             }
         }
@@ -356,7 +356,7 @@ void register(T)(GDExtensionClassLibraryPtr lib) if (is(T == class)) {
 
         uint flags = GDEXTENSION_METHOD_FLAGS_DEFAULT;
 
-        GDExtensionExtensionClassMethodInfo mi = {
+        GDExtensionClassMethodInfo mi = {
             cast(GDExtensionStringNamePtr) snName, //const char *name;
             &mf, //void *method_userdata;
             &mf, //GDExtensionClassMethodCall call_func;


### PR DESCRIPTION
Generator now emits public imports. 
Handle enum, bitfield, typedarray type imports.
Fixes typos that breaks the build.
Moved generator from bin to package root so the generated bindings fetched by existing imports.  _(ugh, maybe just revert and add bin/classes to imports?)_