### PR TITLE
Add numerical to godot String and StringType conversion

### DIFF
--- a/src/godot/string.d
+++ b/src/godot/string.d
@@ -64,6 +64,14 @@ struct String {
     // }
 
     /++
+	Numeric constructor. S can be a built-in numeric type.
+	+/
+    this(S)(in S num) if (isNumeric!S) {
+        import std.conv : text;
+        this(num.text);
+    }
+
+    /++
 	wchar_t constructor. S can be a slice or a null-terminated pointer.
 	+/
     this(S)(in S str) if (isImplicitlyConvertible!(S, const(wchar_t)[]) ||

--- a/src/godot/stringname.d
+++ b/src/godot/stringname.d
@@ -36,6 +36,14 @@ struct StringName {
         auto str = String(s);
         this(str);
     }
+    
+    /++
+	Numeric constructor. S can be a built-in numeric type.
+	+/
+    this(S)(in S num) if (isNumeric!S) {
+        import std.conv : text;
+        this(num.text);
+    }
 
     deprecated("Default struct ctor is not allowed, please use `stringName()` instead")
     @disable this();


### PR DESCRIPTION
This allows for
```d
auto myDouble = 434.0.String;
auto myFloat = 434f.String;

auto myDouble2 = 434.0.StringName;
auto myFloat2 = 434f.StringName;
```

Instead of

```d
import std.conv : text;
auto myDouble = 434.0.text.String;
auto myFloat = 434f.text.String;

auto myDouble2 = 434.0.text.StringName;
auto myFloat2 = 434f.text.StringName;
```