### PR TITLE
Fix out of sync class name and class instance creation

### DIFF
--- a/src/godot/api/register.d
+++ b/src/godot/api/register.d
@@ -253,6 +253,7 @@ void register(T)(GDExtensionClassLibraryPtr lib) if (is(T == class)) {
                 enum string baseName = __traits(identifier, Base);
     }
 
+    // NOTE: Keep in sync with script.d createFunc(T) template
     static if (hasUDA!(T, Rename))
         enum string name = godotName!T;
     else

--- a/src/godot/api/script.d
+++ b/src/godot/api/script.d
@@ -207,6 +207,12 @@ extern (C) package(godot) void* createFunc(T)(void* data) //nothrow @nogc
     import std.exception;
     import godot.api.register : _GODOT_library;
 
+    // NOTE: Keep in sync with register.d register(T) template
+    static if (hasUDA!(T, Rename))
+        enum string name = godotName!T;
+    else 
+        enum string name = __traits(identifier, T);
+
     T t = cast(T) _godot_api.mem_alloc(__traits(classInstanceSize, T));
 
     emplace(t);
@@ -215,7 +221,7 @@ extern (C) package(godot) void* createFunc(T)(void* data) //nothrow @nogc
 
     //static if(extendsGodotBaseClass!T)
     {
-        StringName classname = godotName!T;
+        StringName classname = name;
         StringName snInternalName = (GodotClass!T)._GODOT_internal_name;
         if (!t.owner._godot_object.ptr)
             t.owner._godot_object.ptr = _godot_api.classdb_construct_object(cast(GDExtensionStringNamePtr) snInternalName);

--- a/src/godot/api/wrap.d
+++ b/src/godot/api/wrap.d
@@ -589,10 +589,18 @@ package(godot) struct OnReadyWrapper(T, alias mf) if (is(GodotClass!T : Node)) {
         }
 
         // Finally, call the actual _ready() if it exists.
-        MethodWrapper!(T, mf).callMethod(null, methodData, args, numArgs, r_return, r_error); // note that method_data here is actually D object instance
-        //enum bool isReady(alias func) = "_ready" == godotName!func;
-        //alias readies = Filter!(isReady, godotMethods!T);
-        //static if(readies.length) mixin("t."~__traits(identifier, readies[0])~"();");
+        static if (__traits(hasMember, T, "_ready") 
+                && __traits(compiles, __traits(getDerivedMember, T, "_ready"))) {
+            // superbelko: note that method_data here is actually D object instance 
+            //
+            // Explanation:
+            //   IIRC I just took some existing function that is for regular calls,
+            //   but then there is a special dedicated function for that or something like that,
+            //   but because we already have too much template heavy code 
+            //   adding yet another special case was too cumbersome.
+            //   But... it was quite some time ago and I forgot the details so I maybe wrong.
+            MethodWrapper!(T, mf).callMethod(null, methodData, args, numArgs, r_return, r_error); 
+        }
     }
 }
 


### PR DESCRIPTION
This fixes CaMelCasE issues and also a bug with _ready() called on godot classes where it shouldn't