### PR TITLE
Make LDC great again

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -8,12 +8,12 @@ buildType "doc-json" {
 	buildRequirements "allowWarnings"
 	buildOptions "syntaxOnly"
 }
-dependency "sumtype" version="~>1.2.7"
 dependency "utf_bc" version="~>0.2.1"
 dependency "godot-dlang:util" version="*"
 targetType "library"
 dflags "-fPIC" platform="linux-dmd"
 dflags "-relocation-model=pic" platform="linux-ldc2"
+dflags "-dllimport=defaultLibsOnly" platform="windows-ldc2"
 sourcePaths "src" "classes"
 importPaths "src" "classes"
 subPackage {
@@ -27,7 +27,6 @@ subPackage {
 	description "Godot API binder for use with godot-dlang"
 	dependency "dxml" version="~>0.4.3"
 	dependency "godot-dlang:util" version="*"
-	dependency "sumtype" version="~>1.2.7"
 	dependency "libdparse" version="~>0.20.0"
 	dependency "asdf" version="~>0.7.15"
 	targetType "executable"

--- a/examples/asteroids/dub.json
+++ b/examples/asteroids/dub.json
@@ -7,7 +7,7 @@
 	"copyright": "Copyright © 2018, sheepandshepherd",
 	"license": "MIT",
     
-    "dflags-windows-ldc": ["-link-defaultlib-shared=false"],
+    "dflags-windows-ldc": ["-dllimport=defaultLibsOnly"],
 	
 	"targetType": "dynamicLibrary",
 	"targetPath": "project",

--- a/examples/test/dub.json
+++ b/examples/test/dub.json
@@ -3,7 +3,7 @@
 	"description": "Minimal example to test Godot-D",
 	"targetType": "dynamicLibrary",
 	"targetPath": "project",
-	"dflags-windows-ldc": ["-link-defaultlib-shared=false"],
+	"dflags-windows-ldc": ["-dllimport=defaultLibsOnly"],
 	"libs-windows-debug-dmd": ["libcmtd"],
 	"libs-windows-release-dmd": ["libcmt"],
 	"dependencies":

--- a/src/godot/api/types.d
+++ b/src/godot/api/types.d
@@ -10,7 +10,7 @@ import godot.script, godot.object;
 
 import std.meta;
 
-import sumtype;
+import std.sumtype;
 
 /// 
 struct BuiltInClass {

--- a/src/godot/variant.d
+++ b/src/godot/variant.d
@@ -339,7 +339,7 @@ struct Variant {
 
     ///
     static Variant from(T : GodotType)(T t) {
-        import sumtype : match;
+        import std.sumtype : match;
 
         Variant ret;
         t.match!(
@@ -676,7 +676,7 @@ struct Variant {
 
     /// Is this Variant of the specified `type` or of a subclass of `type`?
     bool isType(GodotType type) const {
-        import sumtype : match;
+        import std.sumtype : match;
 
         return type.match!(
             (Ref!Script script) {


### PR DESCRIPTION
Also switch to std.sumtype, this means that compilers from before Q1 2021 no longer supported.