### PR TITLE
Fix incorrect handling of callBuiltinMethod()

### DIFF
--- a/src/godot/api/bind.d
+++ b/src/godot/api/bind.d
@@ -75,6 +75,9 @@ Return callBuiltinMethod(Return, Args...)(in GDExtensionPtrBuiltInMethod method,
     else
         typeof(null) ret = null;
 
+    import core.stdc.string;
+    memset(&ret, 0, Return.sizeof);
+
     GDExtensionTypePtr[Args.length + 1] _args;
     foreach (i, a; args) {
         _args[i] = &a;

--- a/src/godot/array.d
+++ b/src/godot/array.d
@@ -461,11 +461,10 @@ struct Array {
     ///
     /// Note: `end` is non-inclusive, as in D slice operations, not as in Godot.
     Array slice(size_t start, size_t end, size_t stride = 1, bool deep = false) const {
-        Array ret = void;
+        //Array ret = void;
         //ret._godot_array = _godot_api.array_slice(&_godot_array,
         //	cast(int)start, cast(int)(end-1), cast(int)stride, deep);
-        ret._godot_array = _bind.slice(start, end, stride, deep)._godot_array;
-        return ret;
+        return _bind.slice(start, end, stride, deep);
     }
 
     /++


### PR DESCRIPTION
Fixes hack in Array.slice and fixes yet another default initialization issue even though godot shouldn't read return value in first place