### PR TITLE
Fix invalid virtual calls and floating point parameters bug

### DIFF
--- a/src/godot/abi/types.d
+++ b/src/godot/abi/types.d
@@ -75,12 +75,15 @@ enum GODOT_FALSE = 0;
 alias godot_int = int;
 
 /////// real
-version (GODOT_USE_DOUBLE)
+// note that this one is used in math structs types such as Vector2 or Plane
+// also see godot.api.types.real_t
+version (GODOT_REAL_T_DOUBLE)
     alias godot_real_t = double;
 else
     alias godot_real_t = float;
 
 // TODO: use proper config for GODOT_USE_DOUBLE
+/// Regular Godot floating point, used in methods such as `_process(float delta)` 
 alias godot_float = double;
 
 alias uint64 = ulong;
@@ -100,9 +103,7 @@ alias uint8_t = uint8;
 alias int8 = byte;
 alias int8_t = int8;
 
-// FIXME overriding D alias?
-// AFAIK this is not related to godot_float and always has fixed size
-//alias real_t = double;
+// This is for struct types only, not to be confused with plain floating point variables
 alias real_t = godot.api.types.real_t;
 
 // internal godot id

--- a/src/godot/api/types.d
+++ b/src/godot/api/types.d
@@ -135,7 +135,12 @@ enum GodotError {
     wtf = omfgThisIsVeryVeryBad,
 }
 
-alias real_t = float;
+// Note that this is only used in struct types such as Vector, Plane, etc...
+// Plain floats are double by default (see godot.abi.types.godot_float).
+version(GODOT_REAL_T_DOUBLE)
+    alias real_t = double;
+else
+    alias real_t = float;
 
 enum real_t CMP_EPSILON = 0.00001;
 enum real_t CMP_EPSILON2 = (CMP_EPSILON * CMP_EPSILON);


### PR DESCRIPTION
This should finally deal with #106 and #121, hopefully...

I would like to have a single float type to free the users from the burden of remembering "is this a double or float, an int or long?" but looks like it is better not to mess up with yet another "smart" feature, it is also doesn't seems to be possible because extension_api.json specifies type width using meta flags, i.e. it is all ints or float but has extra size flag such as INT_IS_8_BIT or FLOAT_IS_DOUBLE or something like that.