### PR TITLE
Add github CI

### DIFF
--- a/.github/workflows/d.yml
+++ b/.github/workflows/d.yml
@@ -6,9 +6,9 @@ name: D
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ main, master, develop ]
   pull_request:
-    branches: [ "master" ]
+    branches: [ main, master, develop ]
 
 permissions:
   contents: read
@@ -21,12 +21,44 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: dlang-community/setup-dlang@4c99aa991ce7d19dd3064de0a4f2f6b2f152e2d7
+      with:
+        compiler: ldc-latest
+        
+    - name: 'Godot doesnt works without X server'
+      run: export DISPLAY=:99
+           sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 &
 
-    - name: 'Build & Test'
+    - name: 'Get godot & dump api'
       run: |
-        # Build the project, with its main file included, without unittests
-        dub build --compiler=$DC
-        # Build and run tests, as defined by `unittest` configuration
-        # In this mode, `mainSourceFile` is excluded and `version (unittest)` are included
-        # See https://dub.pm/package-format-json.html#configurations
-        dub test --compiler=$DC
+        curl -O https://downloads.tuxfamily.org/godotengine/4.0.3/Godot_v4.0.3-stable_linux.x86_64.zip
+        sudo apt-get install -y unzip
+        unzip Godot_v4.0.3-stable_linux.x86_64.zip
+        export GDEXE=./Godot_v4.0.3-stable_linux.x86_64
+        echo "GDEXE=$GDEXE" >> $GITHUB_ENV
+        $GDEXE --headless --dump-extension-api
+      
+    - name: 'Generate bindings'
+      run: dub run :generator --verbose -- -j extension_api.json -o
+      
+    - name: 'Build Test Project'
+      run: |
+        dub build :test --verbose --compiler=$DC
+        # a fancy workaround of an issue with being unable to generate assets required to run
+        # https://github.com/godotengine/godot-proposals/issues/1362#issuecomment-1379140108
+        "${{ env.GDEXE }}" --headless --path ./examples/test/project --export-debug "Linux/X11" /path/to/nonexistent/file
+
+    - name: 'Build Asteroids Project'
+      run: |
+        dub build :asteroids --verbose --compiler=$DC
+        "${{ env.GDEXE }}" --headless --path ./examples/asteroids/project --export-debug "Linux/X11" /path/to/nonexistent/file
+
+    - name: 'Run demo project'
+      # currently both godot and godot-dlang doesn't exits cleanly
+      # yet it is useful to see if there is any potential logic errors
+      continue-on-error: true
+      run: timeout 10 "${{ env.GDEXE }}" --verbose --headless --path ./examples/test/project
+
+    - name: 'Run Asteroids project'
+      # currently both godot and godot-dlang doesn't exits cleanly
+      continue-on-error: true
+      run: timeout 10 "${{ env.GDEXE }}" --verbose --headless --path ./examples/asteroids/project

--- a/examples/test/src/example.d
+++ b/examples/test/src/example.d
@@ -402,11 +402,11 @@ class Test : GodotScript!Label {
             // it seems slice operator changes, assert here has 2 elements, but since godot 4 slice now returns only one
             Array b = a.slice(1, a.length, 2);
             print("Array b (a.slice(1, a.length, 2)): ", b);
-            assert(b[].equal([Variant("two")]));
+            assert(b[].equal([Variant("two"), Variant(4.01)]));
 
             Array c = a ~ b;
             print("Array c: ", c);
-            assert(c[].equal(Array.make(1, "two", NodePath("three"), 4.01, "two")[]));
+            assert(c[].equal(Array.make(1, "two", NodePath("three"), 4.01, "two", 4.01)[]));
             Array d = Array.make(5);
             d.appendRange([6, 7]);
             print("Array d: ", d);


### PR DESCRIPTION
Adds CI tests, also fixed array slicing back to what it was like in godot 3.

Note though Godot leaks some renderer resources as well as godot-dlang leaks godot arrays/strings so actual run is optional.