### PR TITLE
Fix potential null reference due to Ref escape in properties

### DIFF
--- a/modules/tools/generator/methods.d
+++ b/modules/tools/generator/methods.d
@@ -536,7 +536,7 @@ class GodotProperty {
         string retType = m.return_type.dType;
         string ret;
         ret ~= "\t/**\n\t" ~ ddoc.replace("\n", "\n\t") ~ "\n\t*/\n";
-        ret ~= "\t@property " ~ retType ~ " " ~ name.replace("/", "_")
+        ret ~= "\t@property " ~ Type.get(retType).dRef ~ " " ~ name.replace("/", "_")
         // ret ~= "\t@property " ~ m.return_type.dType ~ " " ~ name.replace("/", "_")
             .snakeToCamel.escapeDType ~ "() {\n"; /// TODO: const?
         ret ~= "\t\treturn " ~ getter.snakeToCamel.escapeDType ~ "(";

--- a/src/godot/dictionary.d
+++ b/src/godot/dictionary.d
@@ -187,7 +187,7 @@ struct Dictionary {
 
         Variant v = void;
         v._godot_variant = *cast(godot_variant*)&this;
-        JSON json = memnew!JSON();
+        Ref!JSON json = memnew!JSON();
         return json.stringify(v, gs!(`""`), true, false);
 
         //godot_string s = gdextension_interface_dictionary_to_json(&_godot_dictionary);


### PR DESCRIPTION
Ref.refPayload() escapes the reference due to implicit alias this access, this update fixes one such case in getter properties, more info in #152