### PR TITLE
Fix 32-bit builds

### DIFF
--- a/src/godot/abi/types.d
+++ b/src/godot/abi/types.d
@@ -129,11 +129,11 @@ struct godot_array {
 }
 
 struct godot_basis {
-    uint[9] _opaque;
+    godot_real_t[9] _opaque;
 }
 
 struct godot_color {
-    ulong[2] _opaque;
+    float[4] _opaque;
 }
 
 struct godot_dictionary {
@@ -193,6 +193,9 @@ struct godot_transform2d {
 }
 
 struct godot_variant {
+    version(GODOT_REAL_T_DOUBLE)
+    ubyte[40] _opaque;
+    else
     ubyte[24] _opaque;
 }
 

--- a/src/godot/api/wrap.d
+++ b/src/godot/api/wrap.d
@@ -290,11 +290,11 @@ package(godot) struct MethodWrapper(T, alias mf) {
         }
 
         if (args && numArgs)
-            va[0 .. numArgs] = (cast(Variant**) args)[0 .. numArgs];
+            va[0 .. cast(size_t) numArgs] = (cast(Variant**) args)[0 .. cast(size_t) numArgs];
         if (args && numArgs < defaults.length) // <-- optional parameters that godot decided not to pass
         {
             foreach (i; 0 .. defaults.length)
-                va[max(0, numArgs) + i] = &defaults[i];
+                va[max(0, cast(size_t) numArgs) + i] = &defaults[i];
         }
 
         // it seems to work with static calls without this alias,

--- a/src/godot/array.d
+++ b/src/godot/array.d
@@ -311,7 +311,7 @@ struct Array {
 
     size_t count(in Variant v) {
         //return gdextension_interface_array_count(&_godot_array, &v._godot_variant);
-        return _bind.count(v);
+        return cast(size_t) _bind.count(v); // godot always uses long, in this case it should be safe to cast
     }
 
     bool empty() const {
@@ -412,7 +412,7 @@ struct Array {
 
     size_t size() const {
         //return gdextension_interface_array_size(&_godot_array);
-        return _bind.size();
+        return cast(size_t) _bind.size();
     }
 
     alias length = size; // D-style `length`

--- a/src/godot/poolarrays.d
+++ b/src/godot/poolarrays.d
@@ -167,7 +167,7 @@ struct PackedArray(T) {
     }
 
     size_t size() const {
-        return _bind.size();
+        return cast(size_t) _bind.size();
         //mixin("auto s = gdextension_interface_"~(typeName!T)~"_size;");
         //return s(&_godot_array);
     }

--- a/src/godot/string.d
+++ b/src/godot/string.d
@@ -165,7 +165,7 @@ struct String {
     /// Returns the length of the wchar_t array, minus the zero terminator.
     size_t length() const {
         //return _bind.length(); // bug: infinite recursion
-        return gdextension_interface_string_to_utf8_chars(&_godot_string, null, 0);
+        return cast(size_t) gdextension_interface_string_to_utf8_chars(&_godot_string, null, 0);
     }
 
     /// Returns: $(D true) if length is 0

--- a/src/godot/stringname.d
+++ b/src/godot/stringname.d
@@ -62,7 +62,7 @@ struct StringName {
     /// Returns the length of the char32_t array, minus the zero terminator.
     size_t length() const {
         auto len = gdextension_interface_string_to_utf8_chars(&_godot_string_name, null, 0);
-        return len;
+        return cast(size_t) len;
         //return gdextension_interface_string_length(&_godot_string);
     }
 


### PR DESCRIPTION
Now should correctly work with both float and double builds for both x86 and x86_64 targets.
Use version `GODOT_REAL_T_DOUBLE` for godot builds with `double` support enabled.