### PR TITLE
Experimental support for godot base types as classes

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,10 +8,10 @@
             "name": "Debug Generator",
             "type": "code-d",
             "request": "launch",
-            "program": "godot-dlang_generator.exe",
-            "args": ["-j", "extension_api.json", "-o"],
+            "program": "lib/generator.exe",
+            "args": ["-j", "../extension_api.json", "-o"],
             "cwd": "${workspaceRoot}",
-            "preLaunchTask": "Build Generate API"
+            //"preLaunchTask": "Build Generate API"
         },
         {
             "name": "(test project) GD4 editor",
@@ -40,7 +40,8 @@
             "type": "cppvsdbg",
             "request": "launch",
             "program": "C:/godot/bin/godot.windows.editor.dev.x86_64.exe",
-            "args": ["--path", "${workspaceFolder}/examples/test/project"],
+            //"program": "D:/godot/Godot_v4.2-beta5_win32.exe",
+            "args": ["--path", "${workspaceFolder}/examples/test/project", "-v"],
             "stopAtEntry": false,
             "cwd": "${workspaceFolder}",
             "environment": [],

--- a/dub.sdl
+++ b/dub.sdl
@@ -18,6 +18,14 @@ sourcePaths "src" "classes"
 importPaths "src" "classes"
 /* sourceFiles "src/godot/abi/gdnative_interface.i" */
 
+configuration "default" {
+	targetType "library"
+}
+
+configuration "classes" {
+	versions "USE_CLASSES"
+}
+
 preBuildCommands "if [ ! -d \"classes/\" ]; then echo \"ERROR: 'classes' dir not found, did you forgot to generate bindings?\" && exit 1; fi" platform="posix"
 preBuildCommands "if not exist \"classes\\\" ( echo ERROR: 'classes' dir not found, did you forgot to generate bindings? & exit 1 )" platform="windows"
 // preBuildCommands "If (-not (Test-Path classes) ) { Write-Host \"No generated 'classes' dir found, did you forgot to generate bindings?\" -f Red ; exit 1 }" platform="windows"

--- a/examples/test/dub.json
+++ b/examples/test/dub.json
@@ -16,6 +16,17 @@
             "buildOptions": ["debugMode", "debugInfo"],
             "dflags": ["-version=importc"]
         }
-    }
+    },
+	"configurations": [
+		{ 
+			"name": "default"
+		},
+		{
+			"name": "classes",
+			"subConfigurations": { 
+				"godot-dlang": "classes" 
+			}
+		}
+	]
 
 }

--- a/examples/test/project/project.godot
+++ b/examples/test/project/project.godot
@@ -12,7 +12,7 @@ config_version=5
 
 config/name="Godot-D Test"
 run/main_scene="res://Main.tscn"
-config/features=PackedStringArray("4.1")
+config/features=PackedStringArray("4.2")
 config/icon="res://icon.png"
 
 [memory]

--- a/examples/test/src/example.d
+++ b/examples/test/src/example.d
@@ -28,6 +28,9 @@ class Test : GodotScript!Label {
     /++
 	Simulate OOP inheritance and polymorphism with implicit conversion to Label
 	+/
+    version (USE_CLASSES)
+    override typeof(this) owner() => this; // FIXME: used for this test only, don't do that
+    else
     alias owner this;
 
     @Enum enum Flag {
@@ -139,8 +142,23 @@ class Test : GodotScript!Label {
     @Signal @Rename("send_message")
     static void function(String message) sendMessage;
 
+version(USE_CLASSES) {
+
+    @Method
+    override void _ready() {
+          runTest();
+    }
+
+} else {
+
     @Method
     void _ready() {
+        runTest();
+    }
+
+}
+
+    void runTest() {
         // don't do anything in editor
         import godot.engine;
 

--- a/modules/tools/generator/common.d
+++ b/modules/tools/generator/common.d
@@ -1,0 +1,17 @@
+module godot.tools.generator.common;
+
+/// 
+struct Settings {
+    /// (Experimental) Should use classes over structs?
+    bool useClasses;
+}
+
+
+//
+__gshared Settings _settings;
+
+///
+const(Settings) settings() { return _settings; }
+
+///
+void setSettings(Settings newSettings) { _settings = newSettings; }

--- a/modules/tools/generator/package.d
+++ b/modules/tools/generator/package.d
@@ -7,6 +7,7 @@ import godot.tools.generator.methods;
 import godot.tools.generator.enums;
 import godot.tools.generator.doc;
 import godot.tools.generator.api;
+import godot.tools.generator.common;
 
 import godot.tools.generator.d;
 
@@ -30,10 +31,15 @@ int main(string[] args) {
     string extensionsJson = "extension_api.json";
     string godotSource; // TODO: ddoc
     bool overwrite = false;
+    bool useClasses = false;
     auto opt = args.getopt(
         "json|j", "Extensions API JSON (default: extensions_api.json)", &extensionsJson,
         "source|s", "Godot source directory, for documentation (also sets gdnative if unset)", &godotSource,
-        "overwrite|o", "Overwrite outputDir unconditionally", &overwrite
+        "overwrite|o", "Overwrite outputDir unconditionally", &overwrite,
+        "classes|c", "(Experimental) Generate classes instead of structs for Godot API", &useClasses,
+    );
+    setSettings = Settings (
+        useClasses=useClasses,
     );
 
     writeln(args);

--- a/modules/tools/generator/util.d
+++ b/modules/tools/generator/util.d
@@ -690,6 +690,7 @@ string escapeDType(string s, string godotType = "") {
         "version",
         "body",
         "debug",
+        "toString", // Object.toString overload
     );
     switch (s) {
     case "Object":

--- a/src/godot/api/script.d
+++ b/src/godot/api/script.d
@@ -16,6 +16,9 @@ import godot.api.reference;
 Base class for D native scripts. Native script instances will be attached to a
 Godot (C++) object of Base class.
 +/
+version(USE_CLASSES)
+alias GodotScript(Base) = Base;
+else
 class GodotScript(Base) if (isGodotBaseClass!Base) {
     Base owner;
     alias owner this;
@@ -122,6 +125,8 @@ package(godot) void initialize(T)(T t) if (extendsGodotBaseClass!T) {
 }
 
 package(godot) void finalize(T)(T t) if (extendsGodotBaseClass!T) {
+    version (USE_CLASSES)
+      destroy(t);
 }
 
 /++
@@ -153,31 +158,37 @@ RefOrT!T memnew(T)() if (extendsGodotBaseClass!T) {
     auto obj = gdextension_interface_classdb_construct_object(cast(GDExtensionStringNamePtr) snName);
     assert(obj !is null);
 
+    // if this is a D object it was already created using `createFunc` 
+    // which sets the owning D object to it returned here
     T o = cast(T) gdextension_interface_object_get_instance_binding(obj, _GODOT_library, &_instanceCallbacks);
-    //static if(extends!(T, RefCounted))
-    //{
-    //	bool success = o.initRef();
-    //	assert(success, "Failed to init refcount");
-    //}
-    // Set script and let Object create the script instance
-    //o.setScript(NativeScriptTemplate!T);
-    // Skip typecheck in release; should always be T
-    //assert(o.as!T);
-    //T t = cast(T)_godot_nativescript_api.godot_nativescript_get_userdata(o._godot_object);
-    //T t = cast(T) &o._godot_object;
+
     return refOrT(o);
 }
 
 RefOrT!T memnew(T)() if (isGodotBaseClass!T) {
-    import godot.refcounted;
-
     /// FIXME: block those that aren't marked instanciable in API JSON (actually a generator bug)
-    T t = T._new();
+    version (USE_CLASSES) {
+      godot_object o = T._new();
+      if (!o.ptr)
+          return refOrT(T.init);
+      return memnew!T(o);
+    }
+    else
+      return refOrT(T._new());
+}
+
+/// Constructs D class instance and initializes it with godot object
+RefOrT!T memnew(T)(godot_object handle) {
+    import godot.refcounted;
+    import std.conv : emplace;
+    T t = cast(T) gdextension_interface_mem_alloc(__traits(classInstanceSize, T));
+    emplace(t, handle);
+
     static if (extends!(T, RefCounted)) {
         bool success = t.initRef();
         assert(success, "Failed to init refcount");
     }
-    return refOrT(t); /// TODO: remove _new and use only this function?
+    return refOrT(t);
 }
 
 void memdelete(T)(T t) if (isGodotClass!T) {
@@ -218,29 +229,60 @@ extern (C) package(godot) void* createFunc(T)(void* data) //nothrow @nogc
     else 
         enum string name = __traits(identifier, T);
 
-    T t = cast(T) gdextension_interface_mem_alloc(__traits(classInstanceSize, T));
-
+    enum allocSize = __traits(classInstanceSize, T);
+    T t = cast(T) gdextension_interface_mem_alloc(allocSize);
     emplace(t);
-    // class must have default ctor to be properly initialized
-    // t.__ctor();
+
 
     //static if(extendsGodotBaseClass!T)
     {
         StringName classname = name;
-        StringName snInternalName = (GodotClass!T)._GODOT_internal_name;
-        if (!t.owner._godot_object.ptr)
-            t.owner._godot_object.ptr = gdextension_interface_classdb_construct_object(cast(GDExtensionStringNamePtr) snInternalName);
-        gdextension_interface_object_set_instance(cast(void*) t.owner._godot_object.ptr, cast(GDExtensionStringNamePtr) classname, cast(
-                void*) t);
+        version (USE_CLASSES) {
+          static if(extendsGodotBaseClass!T)
+            StringName snInternalName = (BaseClassesTuple!T)[0]._GODOT_internal_name; // parent class name
+          else static if (isGodotBaseClass!T)
+            StringName snInternalName = T._GODOT_internal_name;
+          else
+            static assert(0, "Unknown class name");
+        } else {
+            StringName snInternalName = (GodotClass!T)._GODOT_internal_name;
+        }
+
+        version (USE_CLASSES)
+          const bool hasValidHandle = t._owner.ptr !is null;
+        else
+          const bool hasValidHandle = t.owner._godot_object.ptr !is null;
+        if (!hasValidHandle) {
+            // allocate backing godot object for D one
+            void* obj = gdextension_interface_classdb_construct_object(cast(GDExtensionStringNamePtr) snInternalName);
+
+            version (USE_CLASSES)
+              t._owner = godot_object(obj);
+            else
+              t.owner._godot_object = godot_object(obj);
+        }
+
+        // associate D and Godot objects together
+        version (USE_CLASSES)
+          gdextension_interface_object_set_instance(cast(void*) t._owner.ptr, cast(GDExtensionStringNamePtr) classname, cast(void*) t);
+        else
+          gdextension_interface_object_set_instance(cast(void*) t.owner._godot_object.ptr, cast(GDExtensionStringNamePtr) classname, cast(void*) t);
     }
     //else
     //	t.owner._godot_object.ptr = cast(void*) t;
     godot.initialize(t);
 
-    gdextension_interface_object_set_instance_binding(cast(void*) t.owner._godot_object.ptr, _GODOT_library, cast(
-            void*) t, &_instanceCallbacks);
+    // instance bindings allows to get associated object for Godot object
+    version (USE_CLASSES)
+      gdextension_interface_object_set_instance_binding(cast(void*) t._owner.ptr, _GODOT_library, cast(void*) t, &_instanceCallbacks);
+    else
+      gdextension_interface_object_set_instance_binding(cast(void*) t.owner._godot_object.ptr, _GODOT_library, cast(void*) t, &_instanceCallbacks);
 
-    return cast(void*) t.owner._godot_object.ptr;
+    // return back the godot object
+    version (USE_CLASSES)
+      return cast(void*) t._owner.ptr;
+    else
+      return cast(void*) t.owner._godot_object.ptr;
 }
 
 extern (C) package(godot) void destroyFunc(T)(void* userData, void* instance) //nothrow @nogc
@@ -251,4 +293,21 @@ extern (C) package(godot) void destroyFunc(T)(void* userData, void* instance) //
     godot.finalize(t);
     gdextension_interface_mem_free(cast(void*) t);
     //Mallocator.instance.dispose(t);
+}
+
+/// Returns D object associated with Godot object
+version (USE_CLASSES)
+RefOrT!T getObjectInstance(T)(void* godotObj)
+{
+    // 1. try to get any existing callback first
+    if (auto obj = gdextension_interface_object_get_instance_binding(godotObj, _GODOT_library, null))
+        return refOrT(cast(T) obj);
+    
+    // 2. find more specific callbacks
+    if (auto obj = gdextension_interface_object_get_instance_binding(godotObj, _GODOT_library, &_instanceCallbacks))
+        return refOrT(cast(T) obj);
+
+    // 3. give up and allocate new D object for it...
+    T o = memnew!T(godot_object(godotObj));
+    return refOrT(o);
 }

--- a/src/godot/api/types.d
+++ b/src/godot/api/types.d
@@ -18,7 +18,14 @@ struct BuiltInClass {
 }
 
 /// 
-alias TypeCategories = AliasSeq!(VariantType, BuiltInClass, Ref!Script);
+version(USE_CLASSES) {
+    // FIXME: make Ref work
+    //   the problem is that sumtype is using inout,
+    //   and this doesn't plays well with Ref constructors when using classes
+    alias TypeCategories = AliasSeq!(VariantType, BuiltInClass, Script); 
+}
+else
+    alias TypeCategories = AliasSeq!(VariantType, BuiltInClass, Ref!Script);
 
 /++
 A specific Godot type in one of these type categories:

--- a/src/godot/api/wrap.d
+++ b/src/godot/api/wrap.d
@@ -529,6 +529,7 @@ package(godot) struct MethodWrapperMeta(alias mf) {
 }
 
 // Special wrapper that fetches OnReady members and then calls real _ready 
+// NOTE: test this and use version to choose T/GodotClass!T depending on USE_CLASSES version
 package(godot) struct OnReadyWrapper(T, alias mf) if (is(GodotClass!T : Node)) {
     extern (C) // for calling convention
     static void callOnReady(void* methodData, void* instance,
@@ -599,7 +600,11 @@ package(godot) struct OnReadyWrapper(T, alias mf) if (is(GodotClass!T : Node)) {
                 } else static if (isGodotClass!F && extends!(F, Node)) {
                     // special case: node path
                     auto np = NodePath(result);
-                    mixin("t." ~ n) = cast(F) t.owner.getNode(np);
+                    // FIXME: t.owner vs t, also there is a class with "owner" property exists
+                    version(USE_CLASSES)
+                      mixin("t." ~ n) = t.getNode(np).as!F;
+                    else
+                      mixin("t." ~ n) = cast(F) t.owner.getNode(np);
                 } else static if (isGodotClass!F && extends!(F, Resource)) {
                     // special case: resource load path
                     import godot.resourceloader;


### PR DESCRIPTION
Added new generator flag `-c` to emit classes instead of structs and new package configuration named `classes`, refer to `test` demo to see how to use it, example CLI usage:

```sh
dub run :generator -- -j extension_api.json -o -c
dub build :test -c classes
```