### PR TITLE
More progress

### DIFF
--- a/examples/test/src/example.d
+++ b/examples/test/src/example.d
@@ -170,6 +170,8 @@ version(USE_CLASSES) {
         longNode.setText("This node was set by OnReady");
 
         owner.emitSignal("send_message", "Some text sent by a signal");
+        // alternative syntax using types instead of plain string
+        emit!sendMessage("Some text sent by a signal");
 
         writefln("owner: %x", cast(void*) owner);
         // print() will write into Godot's editor output, unlike writeln

--- a/src/godot/abi/gdextension.d
+++ b/src/godot/abi/gdextension.d
@@ -19,6 +19,26 @@ enum _exclude = [
     "GDExtensionInterfaceGetProcAddress" // ditto
 ];
 
+/// Some functions have irregular names that deviates from normal camelCase to snake_case translation,
+/// this function adjusts the input to get expected output
+private string fixNamesTranslation(string s) {
+    import std.string;
+    enum fixes = [
+        (string str) => str.replace("UserData", "Userdata"),
+        (string str) => str.replace("PlaceHolder", "Placeholder")
+    ];
+
+    static foreach(fix; fixes) {
+        s = fix(s);
+    }
+    return s;
+}
+
+///
+static assert(camelToSnake(fixNamesTranslation("PlaceHolderScriptInstanceCreate")) == "placeholder_script_instance_create");
+///
+static assert(camelToSnake(fixNamesTranslation("CallableCustomGetUserData")) == "callable_custom_get_userdata");
+
 /// helper method that filters out irrelevant functions
 /// e.g. GDExtensionInterfaceGetGodotVersion will be converted into:
 ///   GDExtensionInterfaceGetGodotVersion gdextension_interface_get_godot_version;
@@ -28,7 +48,7 @@ enum bool isFunctionPtr(alias T) = T.startsWith("GDExtensionInterface")
 
 /// this will convert function pointer declaration and create a variable
 static foreach(symname; Filter!(isFunctionPtr, __traits(derivedMembers, gdextension_interface))) {
-    mixin("__gshared " ~ symname ~ " " ~ symname.camelToSnake ~ ";");
+    mixin("__gshared " ~ symname ~ " " ~ fixNamesTranslation(symname).camelToSnake ~ ";");
 }
 
 // load function pointers for GDExtensionInterface
@@ -36,7 +56,7 @@ void loadGDExtensionInterface() {
     static foreach(symname; Filter!(isFunctionPtr, __traits(derivedMembers, gdextension_interface))) {
         // makes up the following loader code:
         //   gdextension_interface_get_godot_version = cast(GDExtensionInterfaceGetGodotVersion) _godot_get_proc_address("get_godot_version");
-        mixin(symname.camelToSnake, " = cast(", symname, ") _godot_get_proc_address(\"", symname.camelToSnake["gdextension_interface_".length..$], "\");");
+        mixin(fixNamesTranslation(symname).camelToSnake, " = cast(", symname, ") _godot_get_proc_address(\"", fixNamesTranslation(symname).camelToSnake["gdextension_interface_".length..$], "\");");
         //pragma(msg, mixin(symname.camelToSnake, " = cast(", symname, ") _godot_get_proc_address(\"", symname.camelToSnake["gdextension_interface_".length..$], "\");"));
     }
 }

--- a/src/godot/api/script.d
+++ b/src/godot/api/script.d
@@ -23,6 +23,17 @@ class GodotScript(Base) if (isGodotBaseClass!Base) {
     Base owner;
     alias owner this;
 
+    /// Helper function that provides typesafe way of emitting signals using 'emit!signal()' syntax
+    GodotError emit(alias Sig, Args...)(Args args) if (hasUDA!(Sig, Signal)) {
+        static assert(
+            // methods with String parameters has helpers that takes regular D strings
+            __traits(isSame, Parameters!Sig, ReplaceAll!(string, String, Args)), 
+            "Can't call signal `" ~ __traits(identifier, Sig) ~ Parameters!Sig.stringof ~ "` with parameters " ~ Args.stringof
+        ); 
+
+        return emitSignal(godotName!Sig, args);
+    }
+
     pragma(inline, true)
     inout(To) as(To)() inout if (isGodotBaseClass!To) {
         static assert(extends!(Base, To), typeof(this).stringof ~ " does not extend " ~ To.stringof);


### PR DESCRIPTION
Fixes #144 - the annoying warning in loader code due to symbol name mismatch.

Adds a new `emit!signal()` helper that uses types instead of plain strings to make signals more typesafe.