### PR TITLE
Unify some of the differences between structs and classes versions

### DIFF
--- a/examples/asteroids/source/asteroids.d
+++ b/examples/asteroids/source/asteroids.d
@@ -18,7 +18,7 @@ mixin GodotNativeLibrary!(
 );
 
 class Asteroids : GodotScript!Node3D {
-    alias owner this;
+    alias _godot_base this;
 
     enum float spread = PI / 4f;
     enum float speed = 20f;

--- a/examples/asteroids/source/player.d
+++ b/examples/asteroids/source/player.d
@@ -7,7 +7,7 @@ import godot.inputevent;
 import godot.engine;
 
 class Player : GodotScript!Area3D {
-    alias owner this;
+    alias _godot_base this;
 
     enum float speed = 25; /// units per second
 

--- a/modules/tools/generator/classes.d
+++ b/modules/tools/generator/classes.d
@@ -320,11 +320,12 @@ public import godot.classdb;`;
         if (settings.useClasses) {
             if (name.godotType == "Object") {
                 ret ~= "\tprotected godot_object _godot_object;\n";
-                ret ~= "\tpublic godot_object _owner() @nogc const nothrow { return cast() _godot_object; }\n";
-                ret ~= "\tpackage(godot) void _owner(godot_object handle) @nogc nothrow { _godot_object = handle; }\n";
+                ret ~= "\tpublic final godot_object _gdextension_handle() @nogc const nothrow { return cast() _godot_object; }\n";
+                ret ~= "\tpackage(godot) void _gdextension_handle(godot_object handle) @nogc nothrow { _godot_object = handle; }\n";
             }
             else if (isBuiltinClass)
             {
+                // WTF: should it be an opaque type as well as in structs?
                 ret ~= "\tpackage(godot) godot_object _godot_object;\n";
             }
         }
@@ -336,6 +337,7 @@ public import godot.classdb;`;
                     ret ~= "Singleton";
                 ret ~= " _GODOT_base; }\n\talias _GODOT_base this;\n";
                 ret ~= "\talias BaseClasses = AliasSeq!(typeof(_GODOT_base), typeof(_GODOT_base).BaseClasses);\n";
+                ret ~= "\n\tref inout(godot_object) _gdextension_handle() inout { return _godot_object; }\n";
             } else {
                 ret ~= "\t" ~ name.asOpaqueType ~ "  _godot_object;\n";
                 ret ~= "\talias BaseClasses = AliasSeq!();\n";
@@ -366,7 +368,7 @@ public import godot.classdb;`;
                 ret ~= "\t\tconst void* a = _godot_object.ptr, b = other._godot_object.ptr; return a is b ? 0 : a < b ? -1 : 1; \n\t}\n";
                 ret ~= "\t/// \n";
                 ret ~= "\tpragma(inline, true) int opCmp(T)(in T other) const if(extendsGodotBaseClass!T) {\n";
-                ret ~= "\t\tconst void* a = _godot_object.ptr, b = other.owner._godot_object.ptr; return a is b ? 0 : a < b ? -1 : 1; \n\t}\n";
+                ret ~= "\t\tconst void* a = _godot_object.ptr, b = other._godot_object.ptr; return a is b ? 0 : a < b ? -1 : 1; \n\t}\n";
             }
             // hash function
             ret ~= "\t/// \n";

--- a/src/godot/api/register.d
+++ b/src/godot/api/register.d
@@ -266,7 +266,7 @@ void register(T)(GDExtensionClassLibraryPtr lib) if (is(T == class)) {
 
     static if (BaseClassesTuple!T.length == 2) // base class is GodotScript; use owner
     {
-            alias Base = typeof(T.owner);
+            alias Base = typeof(T._godot_base);
             alias baseName = Base._GODOT_internal_name;
     }
     else // base class is another D script
@@ -642,7 +642,7 @@ void unregister(T)(GDExtensionClassLibraryPtr lib) if (is(T == class)) {
 
     static if (BaseClassesTuple!T.length == 2) // base class is GodotScript; use owner
     {
-        alias Base = typeof(T.owner);
+        alias Base = typeof(T._godot_base);
         alias baseName = Base._GODOT_internal_name;
     }
     else // base class is another D script

--- a/src/godot/api/wrap.d
+++ b/src/godot/api/wrap.d
@@ -574,11 +574,7 @@ package(godot) struct OnReadyWrapper(T, alias mf) if (is(GodotClass!T : Node)) {
                 } else static if (isGodotClass!F && extends!(F, Node)) {
                     // special case: node path
                     auto np = NodePath(result);
-                    // FIXME: t.owner vs t, also there is a class with "owner" property exists
-                    version(USE_CLASSES)
-                      mixin("t." ~ n) = t.getNode(np).as!F;
-                    else
-                      mixin("t." ~ n) = cast(F) t.owner.getNode(np);
+                    mixin("t." ~ n) = cast(F) t.getNode(np);
                 } else static if (isGodotClass!F && extends!(F, Resource)) {
                     // special case: resource load path
                     import godot.resourceloader;

--- a/src/godot/variant.d
+++ b/src/godot/variant.d
@@ -286,7 +286,7 @@ struct Variant {
     // but probably it should be propely put under version branching
     private static GodotObject objectToGodot(T)(T o) {
         version (USE_CLASSES)
-          return cast(GodotObject) cast() o._owner.ptr ; 
+          return cast(GodotObject) cast() o._gdextension_handle.ptr ; 
         else
           return o.getGodotObject;
     }


### PR DESCRIPTION
Did some renaming and clean-up to smooth out the differences between structs/classes versions, this is a breaking change though as the `owner` is property of Node and it has been renamed to `_godot_base` to avoid name conflicts with Godot API.