### PR TITLE
Update math types API

### DIFF
--- a/src/godot/api/types.d
+++ b/src/godot/api/types.d
@@ -148,9 +148,3 @@ version(GODOT_REAL_T_DOUBLE)
     alias real_t = double;
 else
     alias real_t = float;
-
-enum real_t CMP_EPSILON = 0.00001;
-enum real_t CMP_EPSILON2 = (CMP_EPSILON * CMP_EPSILON);
-
-enum real_t _PLANE_EQ_DOT_EPSILON = 0.999;
-enum real_t _PLANE_EQ_D_EPSILON = 0.0001;

--- a/src/godot/basis.d
+++ b/src/godot/basis.d
@@ -16,8 +16,11 @@ module godot.basis;
 import godot.api.types;
 import godot.vector3;
 import godot.quat;
+import godot.globalenums : EulerOrder;
+import godot.math;
 
 import std.math;
+import std.algorithm.comparison : clamp;
 import std.algorithm.mutation : swap;
 
 /**
@@ -36,10 +39,8 @@ struct Basis {
         ];
     alias rows = elements;
 
-    this(in Vector3 row0, in Vector3 row1, in Vector3 row2) {
-        elements[0] = row0;
-        elements[1] = row1;
-        elements[2] = row2;
+    this(in Vector3 x, in Vector3 y, in Vector3 z) {
+        setColumns(x, y, z);
     }
 
     this(real_t xx, real_t xy, real_t xz, real_t yx, real_t yy, real_t yz, real_t zx, real_t zy, real_t zz) {
@@ -79,26 +80,159 @@ struct Basis {
             co[2] * s, cofac(0, 1, 2, 0) * s, cofac(0, 0, 1, 1) * s);
     }
 
-    bool isEqualApprox(in Basis a, in Basis b) const {
-        for (int i = 0; i < 3; i++) {
-            for (int j = 0; j < 3; j++) {
-                if ((fabs(a.elements[i][j] - b.elements[i][j]) < CMP_EPSILON) == false)
-                    return false;
-            }
-        }
-
-        return true;
+    bool isEqualApprox(in Basis basis) const {
+        return rows[0].isEqualApprox(basis.rows[0]) && rows[1].isEqualApprox(basis.rows[1]) && rows[2].isEqualApprox(basis.rows[2]);
     }
 
     bool isOrthogonal() const {
         Basis id;
         Basis m = (this) * transposed();
 
-        return isEqualApprox(id, m);
+        return m.isEqualApprox(id);
+    }
+
+    bool isDiagonal() const {
+        return (
+			isClose(rows[0][1], 0) && isClose(rows[0][2], 0) &&
+			isClose(rows[1][0], 0) && isClose(rows[1][2], 0) &&
+			isClose(rows[2][0], 0) && isClose(rows[2][1], 0));
     }
 
     bool isRotation() const {
         return fabs(determinant() - 1) < CMP_EPSILON && isOrthogonal();
+    }
+
+    Basis lerp(in Basis to, in real_t weight) const {
+        Basis b;
+        b.rows[0] = rows[0].lerp(to.rows[0], weight);
+        b.rows[1] = rows[1].lerp(to.rows[1], weight);
+        b.rows[2] = rows[2].lerp(to.rows[2], weight);
+
+        return b;
+    }
+
+    Basis slerp(in Basis to, in real_t weight) const {
+        //consider scale
+        Quaternion from = this.quat;
+        Quaternion qto = to.quat;
+
+        Basis b = Basis(from.slerp(qto, weight));
+        b.rows[0] *= .lerp(rows[0].length(), to.rows[0].length(), weight);
+        b.rows[1] *= .lerp(rows[1].length(), to.rows[1].length(), weight);
+        b.rows[2] *= .lerp(rows[2].length(), to.rows[2].length(), weight);
+
+        return b;
+    }
+
+
+    void rotateSh(ref real_t[] values) @nogc {
+        // code by John Hable
+        // http://filmicworlds.com/blog/simple-and-fast-spherical-harmonic-rotation/
+        // this code is Public Domain
+
+        const static real_t s_c3 = 0.94617469575; // (3*sqrt(5))/(4*sqrt(pi))
+        const static real_t s_c4 = -0.31539156525; // (-sqrt(5))/(4*sqrt(pi))
+        const static real_t s_c5 = 0.54627421529; // (sqrt(15))/(4*sqrt(pi))
+
+        const static real_t s_c_scale = 1.0 / 0.91529123286551084;
+        const static real_t s_c_scale_inv = 0.91529123286551084;
+
+        const static real_t s_rc2 = 1.5853309190550713 * s_c_scale;
+        const static real_t s_c4_div_c3 = s_c4 / s_c3;
+        const static real_t s_c4_div_c3_x2 = (s_c4 / s_c3) * 2.0;
+
+        const static real_t s_scale_dst2 = s_c3 * s_c_scale_inv;
+        const static real_t s_scale_dst4 = s_c5 * s_c_scale_inv;
+
+        const real_t[9] src = values[0..9];
+
+        real_t m00 = rows[0][0];
+        real_t m01 = rows[0][1];
+        real_t m02 = rows[0][2];
+        real_t m10 = rows[1][0];
+        real_t m11 = rows[1][1];
+        real_t m12 = rows[1][2];
+        real_t m20 = rows[2][0];
+        real_t m21 = rows[2][1];
+        real_t m22 = rows[2][2];
+
+        values[0] = src[0];
+        values[1] = m11 * src[1] - m12 * src[2] + m10 * src[3];
+        values[2] = -m21 * src[1] + m22 * src[2] - m20 * src[3];
+        values[3] = m01 * src[1] - m02 * src[2] + m00 * src[3];
+
+        real_t sh0 = src[7] + src[8] + src[8] - src[5];
+        real_t sh1 = src[4] + s_rc2 * src[6] + src[7] + src[8];
+        real_t sh2 = src[4];
+        real_t sh3 = -src[7];
+        real_t sh4 = -src[5];
+
+        // Rotations.  R0 and R1 just use the raw matrix columns
+        real_t r2x = m00 + m01;
+        real_t r2y = m10 + m11;
+        real_t r2z = m20 + m21;
+
+        real_t r3x = m00 + m02;
+        real_t r3y = m10 + m12;
+        real_t r3z = m20 + m22;
+
+        real_t r4x = m01 + m02;
+        real_t r4y = m11 + m12;
+        real_t r4z = m21 + m22;
+
+        // dense matrix multiplication one column at a time
+
+        // column 0
+        real_t sh0_x = sh0 * m00;
+        real_t sh0_y = sh0 * m10;
+        real_t d0 = sh0_x * m10;
+        real_t d1 = sh0_y * m20;
+        real_t d2 = sh0 * (m20 * m20 + s_c4_div_c3);
+        real_t d3 = sh0_x * m20;
+        real_t d4 = sh0_x * m00 - sh0_y * m10;
+
+        // column 1
+        real_t sh1_x = sh1 * m02;
+        real_t sh1_y = sh1 * m12;
+        d0 += sh1_x * m12;
+        d1 += sh1_y * m22;
+        d2 += sh1 * (m22 * m22 + s_c4_div_c3);
+        d3 += sh1_x * m22;
+        d4 += sh1_x * m02 - sh1_y * m12;
+
+        // column 2
+        real_t sh2_x = sh2 * r2x;
+        real_t sh2_y = sh2 * r2y;
+        d0 += sh2_x * r2y;
+        d1 += sh2_y * r2z;
+        d2 += sh2 * (r2z * r2z + s_c4_div_c3_x2);
+        d3 += sh2_x * r2z;
+        d4 += sh2_x * r2x - sh2_y * r2y;
+
+        // column 3
+        real_t sh3_x = sh3 * r3x;
+        real_t sh3_y = sh3 * r3y;
+        d0 += sh3_x * r3y;
+        d1 += sh3_y * r3z;
+        d2 += sh3 * (r3z * r3z + s_c4_div_c3_x2);
+        d3 += sh3_x * r3z;
+        d4 += sh3_x * r3x - sh3_y * r3y;
+
+        // column 4
+        real_t sh4_x = sh4 * r4x;
+        real_t sh4_y = sh4 * r4y;
+        d0 += sh4_x * r4y;
+        d1 += sh4_y * r4z;
+        d2 += sh4 * (r4z * r4z + s_c4_div_c3_x2);
+        d3 += sh4_x * r4z;
+        d4 += sh4_x * r4x - sh4_y * r4y;
+
+        // extra multipliers
+        values[4] = d0;
+        values[5] = -d1;
+        values[6] = d2 * s_scale_dst2;
+        values[7] = -d3;
+        values[8] = d4 * s_scale_dst4;
     }
 
     void transpose() {
@@ -127,106 +261,650 @@ struct Basis {
                 elements[0][1] * elements[1][2] - elements[1][1] * elements[0][2]);
     }
 
-    Vector3 getAxis(int p_axis) const {
+    deprecated("use getColumn instead")
+    Vector3 getAxis(int axis) const {
         // get actual basis axis (elements is transposed for performance)
-        return Vector3(elements[0][p_axis], elements[1][p_axis], elements[2][p_axis]);
+        return Vector3(elements[0][axis], elements[1][axis], elements[2][axis]);
     }
 
-    void setAxis(int p_axis, in Vector3 p_value) {
+    deprecated("use setColumn instead")
+    void setAxis(int axis, in Vector3 value) {
         // get actual basis axis (elements is transposed for performance)
-        elements[0][p_axis] = p_value.x;
-        elements[1][p_axis] = p_value.y;
-        elements[2][p_axis] = p_value.z;
+        elements[0][axis] = value.x;
+        elements[1][axis] = value.y;
+        elements[2][axis] = value.z;
     }
 
-    void rotate(in Vector3 p_axis, real_t p_phi) {
-        this = rotated(p_axis, p_phi);
+    void rotate(in Vector3 axis, real_t angle) {
+        this = rotated(axis, angle);
     }
 
-    Basis rotated(in Vector3 p_axis, real_t p_phi) const {
-        return Basis(p_axis, p_phi) * (this);
+    Basis rotated(in Vector3 axis, real_t angle) const {
+        return Basis(axis, angle) * (this);
     }
 
-    void scale(in Vector3 p_scale) {
-        elements[0][0] *= p_scale.x;
-        elements[0][1] *= p_scale.x;
-        elements[0][2] *= p_scale.x;
-        elements[1][0] *= p_scale.y;
-        elements[1][1] *= p_scale.y;
-        elements[1][2] *= p_scale.y;
-        elements[2][0] *= p_scale.z;
-        elements[2][1] *= p_scale.z;
-        elements[2][2] *= p_scale.z;
+    void rotate_local(in Vector3 axis, real_t angle) {
+        // performs a rotation in object-local coordinate system:
+        // M -> (M.R.Minv).M = M.R.
+        this = rotatedLocal(axis, angle);
     }
 
-    Basis scaled(in Vector3 p_scale) const {
+    Basis rotatedLocal(in Vector3 axis, real_t angle) const {
+	    return this * Basis(axis, angle);
+    }
+
+    void rotate(in Vector3 euler, EulerOrder order = EulerOrder.eulerOrderYxz) {
+        this = rotated(euler, order);
+    }
+
+    Basis rotated(in Vector3 euler, EulerOrder order = EulerOrder.eulerOrderYxz) const {
+        return Basis.fromEuler(euler, order) * this;
+    }
+
+    void rotate(in Quaternion quaternion) {
+        this = rotated(quaternion);
+    }
+
+    Basis rotated(in Quaternion quaternion) const {
+        return Basis(quaternion) * this;
+    }
+
+    Vector3 getEulerNormalized(EulerOrder order = EulerOrder.eulerOrderYxz) const {
+        // Assumes that the matrix can be decomposed into a proper rotation and scaling matrix as M = R.S,
+        // and returns the Euler angles corresponding to the rotation part, complementing get_scale().
+        // See the comment in get_scale() for further information.
+        Basis m = orthonormalized();
+        real_t det = m.determinant();
+        if (det < 0) {
+            // Ensure that the determinant is 1, such that result is a proper rotation matrix which can be represented by Euler angles.
+            m.scale(Vector3(-1, -1, -1));
+        }
+
+        return m.getEuler(order);
+    }
+
+    void getRotationAxisAngle(out Vector3 axis, out real_t angle) const {
+        // Assumes that the matrix can be decomposed into a proper rotation and scaling matrix as M = R.S,
+        // and returns the Euler angles corresponding to the rotation part, complementing get_scale().
+        // See the comment in get_scale() for further information.
+        Basis m = orthonormalized();
+        real_t det = m.determinant();
+        if (det < 0) {
+            // Ensure that the determinant is 1, such that result is a proper rotation matrix which can be represented by Euler angles.
+            m.scale(Vector3(-1, -1, -1));
+        }
+
+        m.getAxisAngle(axis, angle);
+    }
+
+    void getRotationAxisAngleLocal(out Vector3 axis, out real_t angle) const {
+        // Assumes that the matrix can be decomposed into a proper rotation and scaling matrix as M = R.S,
+        // and returns the Euler angles corresponding to the rotation part, complementing get_scale().
+        // See the comment in get_scale() for further information.
+        Basis m = transposed();
+        m.orthonormalize();
+        real_t det = m.determinant();
+        if (det < 0) {
+            // Ensure that the determinant is 1, such that result is a proper rotation matrix which can be represented by Euler angles.
+            m.scale(Vector3(-1, -1, -1));
+        }
+
+        m.getAxisAngle(axis, angle);
+        angle = -angle;
+    }
+
+    Quaternion getRotationQuaternion() const {
+        // Assumes that the matrix can be decomposed into a proper rotation and scaling matrix as M = R.S,
+        // and returns the Euler angles corresponding to the rotation part, complementing get_scale().
+        // See the comment in get_scale() for further information.
+        Basis m = orthonormalized();
+        real_t det = m.determinant();
+        if (det < 0) {
+            // Ensure that the determinant is 1, such that result is a proper rotation matrix which can be represented by Euler angles.
+            m.scale(Vector3(-1, -1, -1));
+        }
+
+        return m.getQuaternion();
+    }
+
+    void rotateToAlign(Vector3 start_direction, Vector3 end_direction) {
+        // Takes two vectors and rotates the basis from the first vector to the second vector.
+        // Adopted from: https://gist.github.com/kevinmoran/b45980723e53edeb8a5a43c49f134724
+        const Vector3 axis = start_direction.cross(end_direction).normalized();
+        if (axis.lengthSquared() != 0) {
+            real_t dot = start_direction.dot(end_direction);
+            dot = clamp(dot, -1.0f, 1.0f);
+            const real_t angle_rads = acos(dot);
+            setAxisAngle(axis, angle_rads);
+        }
+    }
+
+    // Decomposes a Basis into a rotation-reflection matrix (an element of the group O(3)) and a positive scaling matrix as B = O.S.
+    // Returns the rotation-reflection matrix via reference argument, and scaling information is returned as a Vector3.
+    // This (internal) function is too specific and named too ugly to expose to users, and probably there's no need to do so.
+    Vector3 rotrefPosscaleDecomposition(out Basis rotref) const {
+        Vector3 scale = getScale();
+        Basis inv_scale = Basis().scaled(scale.inverse()); // this will also absorb the sign of scale
+        rotref = this * inv_scale;
+        return scale.abs();
+    }
+
+    void scale(in Vector3 scale) {
+        elements[0][0] *= scale.x;
+        elements[0][1] *= scale.x;
+        elements[0][2] *= scale.x;
+        elements[1][0] *= scale.y;
+        elements[1][1] *= scale.y;
+        elements[1][2] *= scale.y;
+        elements[2][0] *= scale.z;
+        elements[2][1] *= scale.z;
+        elements[2][2] *= scale.z;
+    }
+
+    Basis scaled(in Vector3 scale) const {
         Basis b = this;
-        b.scale(p_scale);
+        b.scale(scale);
         return b;
     }
 
+    void scaleLocal(in Vector3 scale) {
+        // performs a scaling in object-local coordinate system:
+        // M -> (M.S.Minv).M = M.S.
+        this = scaledLocal(scale);
+    }
+
+    Basis scaledLocal(in Vector3 scale) const {
+        return this * Basis.fromScale(scale);
+    }
+
+    void scaleOrthogonal(in Vector3 scale) {
+        this = scaledOrthogonal(scale);
+    }
+
+    Basis scaledOrthogonal(in Vector3 scale) const {
+        Basis m = this;
+        Vector3 s = Vector3(-1, -1, -1) + scale;
+        Vector3 dots;
+        Basis b;
+        for (int i = 0; i < 3; i++) {
+            for (int j = 0; j < 3; j++) {
+                dots[j] += s[i] * abs(m.getColumn(i).normalized().dot(b.getColumn(j)));
+            }
+        }
+        m.scaleLocal(Vector3(1, 1, 1) + dots);
+        return m;
+    }
+
+    void makeScaleUniform() {
+        float l = (rows[0].length() + rows[1].length() + rows[2].length()) / 3.0f;
+        for (int i = 0; i < 3; i++) {
+            rows[i].normalize();
+            rows[i] *= l;
+        }
+    }
+
+    float getUniformScale() const {
+        return (rows[0].length() + rows[1].length() + rows[2].length()) / 3.0f;
+    }
+
+    /// getScale works with getRotation, use getScaleAbs if you need to enforce positive signature.
     Vector3 getScale() const {
-        // We are assuming M = R.S, and performing a polar decomposition to extract R and S.
-        // FIXME: We eventually need a proper polar decomposition.
-        // As a cheap workaround until then, to ensure that R is a proper rotation matrix with determinant +1
-        // (such that it can be represented by a Quaternion or Euler angles), we absorb the sign flip into the scaling matrix.
-        // As such, it works in conjuction with get_rotation().
-        real_t det_sign = determinant() > 0 ? 1 : -1;
-        return det_sign * Vector3(
-            Vector3(elements[0][0], elements[1][0], elements[2][0]).length,
-            Vector3(elements[0][1], elements[1][1], elements[2][1]).length,
-            Vector3(elements[0][2], elements[1][2], elements[2][2]).length
+        // FIXME: We are assuming M = R.S (R is rotation and S is scaling), and use polar decomposition to extract R and S.
+        // A polar decomposition is M = O.P, where O is an orthogonal matrix (meaning rotation and reflection) and
+        // P is a positive semi-definite matrix (meaning it contains absolute values of scaling along its diagonal).
+        //
+        // Despite being different from what we want to achieve, we can nevertheless make use of polar decomposition
+        // here as follows. We can split O into a rotation and a reflection as O = R.Q, and obtain M = R.S where
+        // we defined S = Q.P. Now, R is a proper rotation matrix and S is a (signed) scaling matrix,
+        // which can involve negative scalings. However, there is a catch: unlike the polar decomposition of M = O.P,
+        // the decomposition of O into a rotation and reflection matrix as O = R.Q is not unique.
+        // Therefore, we are going to do this decomposition by sticking to a particular convention.
+        // This may lead to confusion for some users though.
+        //
+        // The convention we use here is to absorb the sign flip into the scaling matrix.
+        // The same convention is also used in other similar functions such as get_rotation_axis_angle, get_rotation, ...
+        //
+        // A proper way to get rid of this issue would be to store the scaling values (or at least their signs)
+        // as a part of Basis. However, if we go that path, we need to disable direct (write) access to the
+        // matrix elements.
+        //
+        // The rotation part of this decomposition is returned by get_rotation* functions.
+        real_t det_sign = sgn(determinant());
+        return det_sign * getScaleAbs();
+    }
+
+    Vector3 getScaleAbs() const {
+        return Vector3(
+            Vector3(rows[0][0], rows[1][0], rows[2][0]).length(),
+            Vector3(rows[0][1], rows[1][1], rows[2][1]).length(),
+            Vector3(rows[0][2], rows[1][2], rows[2][2]).length()
         );
     }
 
-    Vector3 getEuler() const {
-        // Euler angles in XYZ convention.
-        // See https://en.wikipedia.org/wiki/Euler_angles#Rotation_matrix
-        //
-        // rot =  cy*cz		  -cy*sz		   sy
-        //		cz*sx*sy+cx*sz  cx*cz-sx*sy*sz -cy*sx
-        //	   -cx*cz*sy+sx*sz  cz*sx+cx*sy*sz  cx*cy
-
-        Vector3 euler;
-
-        if (isRotation() == false)
-            return euler;
-
-        euler.y = asin(elements[0][2]);
-        if (euler.y < PI * 0.5) {
-            if (euler.y > -PI * 0.5) {
-                euler.x = atan2(-elements[1][2], elements[2][2]);
-                euler.z = atan2(-elements[0][1], elements[0][0]);
-            } else {
-                real_t r = atan2(elements[1][0], elements[1][1]);
-                euler.z = 0.0;
-                euler.x = euler.z - r;
-            }
-        } else {
-            real_t r = atan2(elements[0][1], elements[1][1]);
-            euler.z = 0;
-            euler.x = r - euler.z;
-        }
-        return euler;
+    Vector3 getScaleLocal() const {
+        real_t det_sign = sgn(determinant());
+        return det_sign * Vector3(rows[0].length(), rows[1].length(), rows[2].length());
     }
 
-    void setEuler(in Vector3 p_euler) {
+    Vector3 getEuler(EulerOrder order = EulerOrder.eulerOrderYxz) const {
+        switch (order) {
+            case EulerOrder.eulerOrderXyz: {
+                // Euler angles in XYZ convention.
+                // See https://en.wikipedia.org/wiki/Euler_angles#Rotation_matrix
+                //
+                // rot =  cy*cz          -cy*sz           sy
+                //        cz*sx*sy+cx*sz  cx*cz-sx*sy*sz -cy*sx
+                //       -cx*cz*sy+sx*sz  cz*sx+cx*sy*sz  cx*cy
+
+                Vector3 euler;
+                real_t sy = rows[0][2];
+                if (sy < (1.0f - cast(real_t)CMP_EPSILON)) {
+                    if (sy > -(1.0f - cast(real_t)CMP_EPSILON)) {
+                        // is this a pure Y rotation?
+                        if (rows[1][0] == 0 && rows[0][1] == 0 && rows[1][2] == 0 && rows[2][1] == 0 && rows[1][1] == 1) {
+                            // return the simplest form (human friendlier in editor and scripts)
+                            euler.x = 0;
+                            euler.y = atan2(rows[0][2], rows[0][0]);
+                            euler.z = 0;
+                        } else {
+                            euler.x = atan2(-rows[1][2], rows[2][2]);
+                            euler.y = asin(sy);
+                            euler.z = atan2(-rows[0][1], rows[0][0]);
+                        }
+                    } else {
+                        euler.x = atan2(rows[2][1], rows[1][1]);
+                        euler.y = -PI_2; // -PI / 2
+                        euler.z = 0.0f;
+                    }
+                } else {
+                    euler.x = atan2(rows[2][1], rows[1][1]);
+                    euler.y = PI_2; // PI / 2
+                    euler.z = 0.0f;
+                }
+                return euler;
+            }
+            case EulerOrder.eulerOrderXzy: {
+                // Euler angles in XZY convention.
+                // See https://en.wikipedia.org/wiki/Euler_angles#Rotation_matrix
+                //
+                // rot =  cz*cy             -sz             cz*sy
+                //        sx*sy+cx*cy*sz    cx*cz           cx*sz*sy-cy*sx
+                //        cy*sx*sz          cz*sx           cx*cy+sx*sz*sy
+
+                Vector3 euler;
+                real_t sz = rows[0][1];
+                if (sz < (1.0f - cast(real_t)CMP_EPSILON)) {
+                    if (sz > -(1.0f - cast(real_t)CMP_EPSILON)) {
+                        euler.x = atan2(rows[2][1], rows[1][1]);
+                        euler.y = atan2(rows[0][2], rows[0][0]);
+                        euler.z = asin(-sz);
+                    } else {
+                        // It's -1
+                        euler.x = -atan2(rows[1][2], rows[2][2]);
+                        euler.y = 0.0f;
+                        euler.z = PI_2; // PI / 2
+                    }
+                } else {
+                    // It's 1
+                    euler.x = -atan2(rows[1][2], rows[2][2]);
+                    euler.y = 0.0f;
+                    euler.z = -PI_2; // -PI / 2
+                }
+                return euler;
+            }
+            case EulerOrder.eulerOrderYxz: {
+                // Euler angles in YXZ convention.
+                // See https://en.wikipedia.org/wiki/Euler_angles#Rotation_matrix
+                //
+                // rot =  cy*cz+sy*sx*sz    cz*sy*sx-cy*sz        cx*sy
+                //        cx*sz             cx*cz                 -sx
+                //        cy*sx*sz-cz*sy    cy*cz*sx+sy*sz        cy*cx
+
+                Vector3 euler;
+
+                real_t m12 = rows[1][2];
+
+                if (m12 < (1 - cast(real_t)CMP_EPSILON)) {
+                    if (m12 > -(1 - cast(real_t)CMP_EPSILON)) {
+                        // is this a pure X rotation?
+                        if (rows[1][0] == 0 && rows[0][1] == 0 && rows[0][2] == 0 && rows[2][0] == 0 && rows[0][0] == 1) {
+                            // return the simplest form (human friendlier in editor and scripts)
+                            euler.x = atan2(-m12, rows[1][1]);
+                            euler.y = 0;
+                            euler.z = 0;
+                        } else {
+                            euler.x = asin(-m12);
+                            euler.y = atan2(rows[0][2], rows[2][2]);
+                            euler.z = atan2(rows[1][0], rows[1][1]);
+                        }
+                    } else { // m12 == -1
+                        euler.x = PI_2;
+                        euler.y = atan2(rows[0][1], rows[0][0]);
+                        euler.z = 0;
+                    }
+                } else { // m12 == 1
+                    euler.x = -PI_2;
+                    euler.y = -atan2(rows[0][1], rows[0][0]);
+                    euler.z = 0;
+                }
+
+                return euler;
+            }
+            case EulerOrder.eulerOrderYzx: {
+                // Euler angles in YZX convention.
+                // See https://en.wikipedia.org/wiki/Euler_angles#Rotation_matrix
+                //
+                // rot =  cy*cz             sy*sx-cy*cx*sz     cx*sy+cy*sz*sx
+                //        sz                cz*cx              -cz*sx
+                //        -cz*sy            cy*sx+cx*sy*sz     cy*cx-sy*sz*sx
+
+                Vector3 euler;
+                real_t sz = rows[1][0];
+                if (sz < (1.0f - cast(real_t)CMP_EPSILON)) {
+                    if (sz > -(1.0f - cast(real_t)CMP_EPSILON)) {
+                        euler.x = atan2(-rows[1][2], rows[1][1]);
+                        euler.y = atan2(-rows[2][0], rows[0][0]);
+                        euler.z = asin(sz);
+                    } else {
+                        // It's -1
+                        euler.x = atan2(rows[2][1], rows[2][2]);
+                        euler.y = 0.0f;
+                        euler.z = -PI_2;
+                    }
+                } else {
+                    // It's 1
+                    euler.x = atan2(rows[2][1], rows[2][2]);
+                    euler.y = 0.0f;
+                    euler.z = PI_2;
+                }
+                return euler;
+            }
+            case EulerOrder.eulerOrderZxy: {
+                // Euler angles in ZXY convention.
+                // See https://en.wikipedia.org/wiki/Euler_angles#Rotation_matrix
+                //
+                // rot =  cz*cy-sz*sx*sy    -cx*sz                cz*sy+cy*sz*sx
+                //        cy*sz+cz*sx*sy    cz*cx                 sz*sy-cz*cy*sx
+                //        -cx*sy            sx                    cx*cy
+                Vector3 euler;
+                real_t sx = rows[2][1];
+                if (sx < (1.0f - cast(real_t)CMP_EPSILON)) {
+                    if (sx > -(1.0f - cast(real_t)CMP_EPSILON)) {
+                        euler.x = asin(sx);
+                        euler.y = atan2(-rows[2][0], rows[2][2]);
+                        euler.z = atan2(-rows[0][1], rows[1][1]);
+                    } else {
+                        // It's -1
+                        euler.x = -PI_2;
+                        euler.y = atan2(rows[0][2], rows[0][0]);
+                        euler.z = 0;
+                    }
+                } else {
+                    // It's 1
+                    euler.x = PI_2;
+                    euler.y = atan2(rows[0][2], rows[0][0]);
+                    euler.z = 0;
+                }
+                return euler;
+            }
+            case EulerOrder.eulerOrderZyx: {
+                // Euler angles in ZYX convention.
+                // See https://en.wikipedia.org/wiki/Euler_angles#Rotation_matrix
+                //
+                // rot =  cz*cy             cz*sy*sx-cx*sz        sz*sx+cz*cx*cy
+                //        cy*sz             cz*cx+sz*sy*sx        cx*sz*sy-cz*sx
+                //        -sy               cy*sx                 cy*cx
+                Vector3 euler;
+                real_t sy = rows[2][0];
+                if (sy < (1.0f - cast(real_t)CMP_EPSILON)) {
+                    if (sy > -(1.0f - cast(real_t)CMP_EPSILON)) {
+                        euler.x = atan2(rows[2][1], rows[2][2]);
+                        euler.y = asin(-sy);
+                        euler.z = atan2(rows[1][0], rows[0][0]);
+                    } else {
+                        // It's -1
+                        euler.x = 0;
+                        euler.y = PI_2;
+                        euler.z = -atan2(rows[0][1], rows[1][1]);
+                    }
+                } else {
+                    // It's 1
+                    euler.x = 0;
+                    euler.y = -PI_2;
+                    euler.z = -atan2(rows[0][1], rows[1][1]);
+                }
+                return euler;
+            }
+            default: {
+                assert(0); // should never happen
+            }
+        }
+        // unreachable
+        //return Vector3();
+    }
+
+    void setEuler(in Vector3 euler, EulerOrder order = EulerOrder.eulerOrderYxz) {
         real_t c, s;
 
-        c = cos(p_euler.x);
-        s = sin(p_euler.x);
+        c = cos(euler.x);
+        s = sin(euler.x);
         Basis xmat = Basis(1.0, 0.0, 0.0, 0.0, c, -s, 0.0, s, c);
 
-        c = cos(p_euler.y);
-        s = sin(p_euler.y);
+        c = cos(euler.y);
+        s = sin(euler.y);
         Basis ymat = Basis(c, 0.0, s, 0.0, 1.0, 0.0, -s, 0.0, c);
 
-        c = cos(p_euler.z);
-        s = sin(p_euler.z);
+        c = cos(euler.z);
+        s = sin(euler.z);
         Basis zmat = Basis(c, -s, 0.0, s, c, 0.0, 0.0, 0.0, 1.0);
 
-        //optimizer will optimize away all this anyway
-        this = xmat * (ymat * zmat);
+        switch (order) {
+            case EulerOrder.eulerOrderXyz: {
+                this = xmat * (ymat * zmat);
+            } break;
+            case EulerOrder.eulerOrderXzy: {
+                this = xmat * zmat * ymat;
+            } break;
+            case EulerOrder.eulerOrderYxz: {
+                this = ymat * xmat * zmat;
+            } break;
+            case EulerOrder.eulerOrderYzx: {
+                this = ymat * zmat * xmat;
+            } break;
+            case EulerOrder.eulerOrderZxy: {
+                this = zmat * xmat * ymat;
+            } break;
+            case EulerOrder.eulerOrderZyx: {
+                this = zmat * ymat * xmat;
+            } break;
+            default: {
+                assert(0, "Invalid order parameter for setEuler(vec3,order)");
+            }
+        }
+    }
+
+    static Basis fromEuler(in Vector3 euler, EulerOrder order = EulerOrder.eulerOrderYxz) {
+		Basis b;
+		b.setEuler(euler, order);
+		return b;
+    }
+
+    Quaternion getQuaternion() const {
+        /* Allow getting a quaternion from an unnormalized transform */
+        Basis m = this;
+        real_t trace = m.rows[0][0] + m.rows[1][1] + m.rows[2][2];
+        real_t[4] temp;
+
+        if (trace > 0.0f) {
+            real_t s = sqrt(trace + 1.0f);
+            temp[3] = (s * 0.5f);
+            s = 0.5f / s;
+
+            temp[0] = ((m.rows[2][1] - m.rows[1][2]) * s);
+            temp[1] = ((m.rows[0][2] - m.rows[2][0]) * s);
+            temp[2] = ((m.rows[1][0] - m.rows[0][1]) * s);
+        } else {
+            int i = m.rows[0][0] < m.rows[1][1]
+                    ? (m.rows[1][1] < m.rows[2][2] ? 2 : 1)
+                    : (m.rows[0][0] < m.rows[2][2] ? 2 : 0);
+            int j = (i + 1) % 3;
+            int k = (i + 2) % 3;
+
+            real_t s = sqrt(m.rows[i][i] - m.rows[j][j] - m.rows[k][k] + 1.0f);
+            temp[i] = s * 0.5f;
+            s = 0.5f / s;
+
+            temp[3] = (m.rows[k][j] - m.rows[j][k]) * s;
+            temp[j] = (m.rows[j][i] + m.rows[i][j]) * s;
+            temp[k] = (m.rows[k][i] + m.rows[i][k]) * s;
+        }
+
+        return Quaternion(temp[0], temp[1], temp[2], temp[3]);
+    }
+
+    void setQuaternion(in Quaternion quaternion) {
+        real_t d = quaternion.lengthSquared();
+        real_t s = 2.0f / d;
+        real_t xs = quaternion.x * s, ys = quaternion.y * s, zs = quaternion.z * s;
+        real_t wx = quaternion.w * xs, wy = quaternion.w * ys, wz = quaternion.w * zs;
+        real_t xx = quaternion.x * xs, xy = quaternion.x * ys, xz = quaternion.x * zs;
+        real_t yy = quaternion.y * ys, yz = quaternion.y * zs, zz = quaternion.z * zs;
+        set(1.0f - (yy + zz), xy - wz, xz + wy,
+                xy + wz, 1.0f - (xx + zz), yz - wx,
+                xz - wy, yz + wx, 1.0f - (xx + yy));
+    }
+
+    void fromZ(in Vector3 z) {
+        if (abs(z.z) > cast(real_t)SQRT1_2) {
+            // choose p in y-z plane
+            real_t a = z[1] * z[1] + z[2] * z[2];
+            real_t k = 1.0f / sqrt(a);
+            rows[0] = Vector3(0, -z[2] * k, z[1] * k);
+            rows[1] = Vector3(a * k, -z[0] * rows[0][2], z[0] * rows[0][1]);
+        } else {
+            // choose p in x-y plane
+            real_t a = z.x * z.x + z.y * z.y;
+            real_t k = 1.0f / sqrt(a);
+            rows[0] = Vector3(-z.y * k, z.x * k, 0);
+            rows[1] = Vector3(-z.z * rows[0].y, z.z * rows[0].x, a * k);
+        }
+        rows[2] = z;
+    }
+
+
+    void getAxisAngle(out Vector3 axis, out real_t angle) const {
+        // https://www.euclideanspace.com/maths/geometry/rotations/conversions/matrixToAngle/index.htm
+        real_t x, y, z; // Variables for result.
+        if (isClose(rows[0][1] - rows[1][0], 0) && isClose(rows[0][2] - rows[2][0], 0) && isClose(rows[1][2] - rows[2][1], 0)) {
+            // Singularity found.
+            // First check for identity matrix which must have +1 for all terms in leading diagonal and zero in other terms.
+            if (isDiagonal() && (abs(rows[0][0] + rows[1][1] + rows[2][2] - 3) < 3 * CMP_EPSILON)) {
+                // This singularity is identity matrix so angle = 0.
+                axis = Vector3(0, 1, 0);
+                angle = 0;
+                return;
+            }
+            // Otherwise this singularity is angle = 180.
+            real_t xx = (rows[0][0] + 1) / 2;
+            real_t yy = (rows[1][1] + 1) / 2;
+            real_t zz = (rows[2][2] + 1) / 2;
+            real_t xy = (rows[0][1] + rows[1][0]) / 4;
+            real_t xz = (rows[0][2] + rows[2][0]) / 4;
+            real_t yz = (rows[1][2] + rows[2][1]) / 4;
+
+            if ((xx > yy) && (xx > zz)) { // rows[0][0] is the largest diagonal term.
+                if (xx < CMP_EPSILON) {
+                    x = 0;
+                    y = SQRT1_2;
+                    z = SQRT1_2;
+                } else {
+                    x = sqrt(xx);
+                    y = xy / x;
+                    z = xz / x;
+                }
+            } else if (yy > zz) { // rows[1][1] is the largest diagonal term.
+                if (yy < CMP_EPSILON) {
+                    x = SQRT1_2;
+                    y = 0;
+                    z = SQRT1_2;
+                } else {
+                    y = sqrt(yy);
+                    x = xy / y;
+                    z = yz / y;
+                }
+            } else { // rows[2][2] is the largest diagonal term so base result on this.
+                if (zz < CMP_EPSILON) {
+                    x = SQRT1_2;
+                    y = SQRT1_2;
+                    z = 0;
+                } else {
+                    z = sqrt(zz);
+                    x = xz / z;
+                    y = yz / z;
+                }
+            }
+            axis = Vector3(x, y, z);
+            angle = PI;
+            return;
+        }
+        // As we have reached here there are no singularities so we can handle normally.
+        double s = sqrt((rows[2][1] - rows[1][2]) * (rows[2][1] - rows[1][2]) + (rows[0][2] - rows[2][0]) * (rows[0][2] - rows[2][0]) + (rows[1][0] - rows[0][1]) * (rows[1][0] - rows[0][1])); // Used to normalise.
+
+        if (abs(s) < CMP_EPSILON) {
+            // Prevent divide by zero, should not happen if matrix is orthogonal and should be caught by singularity test above.
+            s = 1;
+        }
+
+        x = (rows[2][1] - rows[1][2]) / s;
+        y = (rows[0][2] - rows[2][0]) / s;
+        z = (rows[1][0] - rows[0][1]) / s;
+
+        axis = Vector3(x, y, z);
+        // CLAMP to avoid NaN if the value passed to acos is not in [0,1].
+        angle = acos(clamp((rows[0][0] + rows[1][1] + rows[2][2] - 1) / 2, cast(real_t)0.0, cast(real_t)1.0));
+    }
+
+
+    void setAxisAngle(in Vector3 axis, real_t angle) {
+        // Rotation matrix from axis and angle, see https://en.wikipedia.org/wiki/Rotation_matrix#Rotation_matrix_from_axis_angle
+        Vector3 axis_sq = Vector3(axis.x * axis.x, axis.y * axis.y, axis.z * axis.z);
+        real_t cosine = cos(angle);
+        rows[0][0] = axis_sq.x + cosine * (1.0f - axis_sq.x);
+        rows[1][1] = axis_sq.y + cosine * (1.0f - axis_sq.y);
+        rows[2][2] = axis_sq.z + cosine * (1.0f - axis_sq.z);
+
+        real_t sine = sin(angle);
+        real_t t = 1 - cosine;
+
+        real_t xyzt = axis.x * axis.y * t;
+        real_t zyxs = axis.z * sine;
+        rows[0][1] = xyzt - zyxs;
+        rows[1][0] = xyzt + zyxs;
+
+        xyzt = axis.x * axis.z * t;
+        zyxs = axis.y * sine;
+        rows[0][2] = xyzt + zyxs;
+        rows[2][0] = xyzt - zyxs;
+
+        xyzt = axis.y * axis.z * t;
+        zyxs = axis.x * sine;
+        rows[1][2] = xyzt - zyxs;
+        rows[2][1] = xyzt + zyxs;
+    }
+
+    void setAxisAngleScale(in Vector3 axis, real_t angle, in Vector3 scale) {
+        _setDiagonal(scale);
+        rotate(axis, angle);
+    }
+
+    void setEulerScale(in Vector3 euler, in Vector3 scale, EulerOrder order = EulerOrder.eulerOrderYxz) {
+        _setDiagonal(scale);
+        rotate(euler, order);
+    }
+
+    void setQuaternionScale(in Quaternion quaternion, in Vector3 scale) {
+        _setDiagonal(scale);
+        rotate(quaternion);
     }
 
     // transposed dot products
@@ -252,76 +930,76 @@ struct Basis {
         return 0;
     }
 
-    Vector3 xform(in Vector3 p_vector) const {
+    Vector3 xform(in Vector3 vector) const {
         return Vector3(
-            elements[0].dot(p_vector),
-            elements[1].dot(p_vector),
-            elements[2].dot(p_vector)
+            elements[0].dot(vector),
+            elements[1].dot(vector),
+            elements[2].dot(vector)
         );
     }
 
-    Vector3 xformInv(in Vector3 p_vector) const {
+    Vector3 xformInv(in Vector3 vector) const {
         return Vector3(
-            (elements[0][0] * p_vector.x) + (elements[1][0] * p_vector.y) + (
-                elements[2][0] * p_vector.z),
-            (elements[0][1] * p_vector.x) + (elements[1][1] * p_vector.y) + (
-                elements[2][1] * p_vector.z),
-            (elements[0][2] * p_vector.x) + (elements[1][2] * p_vector.y) + (
-                elements[2][2] * p_vector.z)
+            (elements[0][0] * vector.x) + (elements[1][0] * vector.y) + (
+                elements[2][0] * vector.z),
+            (elements[0][1] * vector.x) + (elements[1][1] * vector.y) + (
+                elements[2][1] * vector.z),
+            (elements[0][2] * vector.x) + (elements[1][2] * vector.y) + (
+                elements[2][2] * vector.z)
         );
     }
 
-    void opOpAssign(string op : "*")(in Basis p_matrix) {
+    void opOpAssign(string op : "*")(in Basis matrix) {
         set(
-            p_matrix.tdotx(elements[0]), p_matrix.tdoty(elements[0]), p_matrix.tdotz(elements[0]),
-            p_matrix.tdotx(elements[1]), p_matrix.tdoty(elements[1]), p_matrix.tdotz(elements[1]),
-            p_matrix.tdotx(elements[2]), p_matrix.tdoty(elements[2]), p_matrix.tdotz(elements[2]));
+            matrix.tdotx(elements[0]), matrix.tdoty(elements[0]), matrix.tdotz(elements[0]),
+            matrix.tdotx(elements[1]), matrix.tdoty(elements[1]), matrix.tdotz(elements[1]),
+            matrix.tdotx(elements[2]), matrix.tdoty(elements[2]), matrix.tdotz(elements[2]));
 
     }
 
-    Basis opBinary(string op : "*")(in Basis p_matrix) const {
+    Basis opBinary(string op : "*")(in Basis matrix) const {
         return Basis(
-            p_matrix.tdotx(elements[0]), p_matrix.tdoty(elements[0]), p_matrix.tdotz(elements[0]),
-            p_matrix.tdotx(elements[1]), p_matrix.tdoty(elements[1]), p_matrix.tdotz(elements[1]),
-            p_matrix.tdotx(elements[2]), p_matrix.tdoty(elements[2]), p_matrix.tdotz(elements[2]));
+            matrix.tdotx(elements[0]), matrix.tdoty(elements[0]), matrix.tdotz(elements[0]),
+            matrix.tdotx(elements[1]), matrix.tdoty(elements[1]), matrix.tdotz(elements[1]),
+            matrix.tdotx(elements[2]), matrix.tdoty(elements[2]), matrix.tdotz(elements[2]));
 
     }
 
-    void opOpAssign(string op : "+")(in Basis p_matrix) {
-        elements[0] += p_matrix.elements[0];
-        elements[1] += p_matrix.elements[1];
-        elements[2] += p_matrix.elements[2];
+    void opOpAssign(string op : "+")(in Basis matrix) {
+        elements[0] += matrix.elements[0];
+        elements[1] += matrix.elements[1];
+        elements[2] += matrix.elements[2];
     }
 
-    Basis opBinary(string op : "+")(in Basis p_matrix) const {
+    Basis opBinary(string op : "+")(in Basis matrix) const {
         Basis ret = this;
-        ret += p_matrix;
+        ret += matrix;
         return ret;
     }
 
-    void opOpAssign(string op : "-")(in Basis p_matrix) {
-        elements[0] -= p_matrix.elements[0];
-        elements[1] -= p_matrix.elements[1];
-        elements[2] -= p_matrix.elements[2];
+    void opOpAssign(string op : "-")(in Basis matrix) {
+        elements[0] -= matrix.elements[0];
+        elements[1] -= matrix.elements[1];
+        elements[2] -= matrix.elements[2];
     }
 
-    Basis opBinary(string op : "-")(in Basis p_matrix) const {
+    Basis opBinary(string op : "-")(in Basis matrix) const {
         Basis ret = this;
-        ret -= p_matrix;
+        ret -= matrix;
         return ret;
     }
 
-    void opOpAssign(string op : "*")(real_t p_val) {
+    void opOpAssign(string op : "*")(real_t val) {
 
-        elements[0] *= p_val;
-        elements[1] *= p_val;
-        elements[2] *= p_val;
+        elements[0] *= val;
+        elements[1] *= val;
+        elements[2] *= val;
     }
 
-    Basis opBinary(string op : "*")(real_t p_val) const {
+    Basis opBinary(string op : "*")(real_t val) const {
 
         Basis ret = this;
-        ret *= p_val;
+        ret *= val;
         return ret;
     }
 
@@ -346,9 +1024,22 @@ struct Basis {
         elements[2][2] = zz;
     }
 
+    void setColumns(in Vector3 x, in Vector3 y, in Vector3 z) {
+		setColumn(0, x);
+		setColumn(1, y);
+		setColumn(2, z);
+	}
+
     Vector3 getColumn(int i) const {
         return Vector3(elements[0][i], elements[1][i], elements[2][i]);
     }
+
+    void setColumn(int index, in Vector3 value) {
+		// Set actual basis axis column (we store transposed as rows for performance).
+		rows[0][index] = value.x;
+		rows[1][index] = value.y;
+		rows[2][index] = value.z;
+	}
 
     Vector3 getRow(int i) const {
         return Vector3(elements[i][0], elements[i][1], elements[i][2]);
@@ -358,11 +1049,17 @@ struct Basis {
         return Vector3(elements[0][0], elements[1][1], elements[2][2]);
     }
 
-    void setRow(int i, in Vector3 p_row) {
-        elements[i][0] = p_row.x;
-        elements[i][1] = p_row.y;
-        elements[i][2] = p_row.z;
+    void setRow(int i, in Vector3 row) {
+        elements[i][0] = row.x;
+        elements[i][1] = row.y;
+        elements[i][2] = row.z;
     }
+
+    void setZero() {
+		rows[0].zero();
+		rows[1].zero();
+		rows[2].zero();
+	}
 
     Basis transposeXform(in Basis m) const {
         return Basis(
@@ -382,9 +1079,9 @@ struct Basis {
 
         // Gram-Schmidt Process
 
-        Vector3 x = getAxis(0);
-        Vector3 y = getAxis(1);
-        Vector3 z = getAxis(2);
+        Vector3 x = getColumn(0);
+        Vector3 y = getColumn(1);
+        Vector3 z = getColumn(2);
 
         x.normalize();
         y = (y - x * (x.dot(y)));
@@ -392,15 +1089,27 @@ struct Basis {
         z = (z - x * (x.dot(z)) - y * (y.dot(z)));
         z.normalize();
 
-        setAxis(0, x);
-        setAxis(1, y);
-        setAxis(2, z);
+        setColumn(0, x);
+        setColumn(1, y);
+        setColumn(2, z);
     }
 
     Basis orthonormalized() const {
         Basis b = this;
         b.orthonormalize();
         return b;
+    }
+
+    void orthogonalize() {
+        Vector3 scl = getScale();
+	    orthonormalize();
+	    scaleLocal(scl);
+    }
+
+    Basis orthogonalized() const {
+        Basis c = this;
+        c.orthogonalize();
+        return c;
     }
 
     bool isSymmetric() const {
@@ -529,50 +1238,46 @@ struct Basis {
         return 0;
     }
 
-    void setOrthogonalIndex(int p_index) {
+    void setOrthogonalIndex(int index) {
         //there only exist 24 orthogonal bases in r3
-        ///ERR_FAIL_COND(p_index >= 24);
-        this = _ortho_bases[p_index];
+        ///ERR_FAIL_COND(index >= 24);
+        this = _ortho_bases[index];
     }
 
-    this(in Vector3 p_euler) {
-        setEuler(p_euler);
+    static Basis lookingAt(in Vector3 target, in Vector3 up = Vector3(0, 1, 0)) {
+        Vector3 v_z = -target.normalized();
+        Vector3 v_x = up.cross(v_z);
+        v_x.normalize();
+        Vector3 v_y = v_z.cross(v_x);
+
+        Basis basis;
+        basis.setColumns(v_x, v_y, v_z);
+        return basis;
     }
 
-    this(in Quaternion p_quat) {
-
-        real_t d = p_quat.lengthSquared();
-        real_t s = 2.0 / d;
-        real_t xs = p_quat.x * s, ys = p_quat.y * s, zs = p_quat.z * s;
-        real_t wx = p_quat.w * xs, wy = p_quat.w * ys, wz = p_quat.w * zs;
-        real_t xx = p_quat.x * xs, xy = p_quat.x * ys, xz = p_quat.x * zs;
-        real_t yy = p_quat.y * ys, yz = p_quat.y * zs, zz = p_quat.z * zs;
-        set(1.0 - (yy + zz), xy - wz, xz + wy,
-            xy + wz, 1.0 - (xx + zz), yz - wx,
-            xz - wy, yz + wx, 1.0 - (xx + yy));
-
+    static Basis fromScale(in Vector3 scale) {
+        return Basis(scale.x, 0, 0, 0, scale.y, 0, 0, 0, scale.z);
     }
 
-    this(in Vector3 p_axis, real_t p_phi) {
-        // Rotation matrix from axis and angle, see https://en.wikipedia.org/wiki/Rotation_matrix#Rotation_matrix_from_axis_and_angle
+    deprecated("use Basis.fromEuler()")
+    this(in Vector3 euler) {
+        setEuler(euler);
+    }
 
-        Vector3 axis_sq = Vector3(p_axis.x * p_axis.x, p_axis.y * p_axis.y, p_axis.z * p_axis.z);
+    this(in Quaternion quaternion) {
+        setQuaternion(quaternion);
+    }
 
-        real_t cosine = cos(p_phi);
-        real_t sine = sin(p_phi);
+    this(in Quaternion quaternion, in Vector3 scale) { 
+        setQuaternionScale(quaternion, scale); 
+    }
 
-        elements[0][0] = axis_sq.x + cosine * (1.0 - axis_sq.x);
-        elements[0][1] = p_axis.x * p_axis.y * (1.0 - cosine) - p_axis.z * sine;
-        elements[0][2] = p_axis.z * p_axis.x * (1.0 - cosine) + p_axis.y * sine;
+    this(in Vector3 axis, real_t angle) {
+        setAxisAngle(axis, angle);
+    }
 
-        elements[1][0] = p_axis.x * p_axis.y * (1.0 - cosine) + p_axis.z * sine;
-        elements[1][1] = axis_sq.y + cosine * (1.0 - axis_sq.y);
-        elements[1][2] = p_axis.y * p_axis.z * (1.0 - cosine) - p_axis.x * sine;
-
-        elements[2][0] = p_axis.z * p_axis.x * (1.0 - cosine) - p_axis.y * sine;
-        elements[2][1] = p_axis.y * p_axis.z * (1.0 - cosine) + p_axis.x * sine;
-        elements[2][2] = axis_sq.z + cosine * (1.0 - axis_sq.z);
-
+    this(in Vector3 axis, real_t angle, in Vector3 scale) { 
+        setAxisAngleScale(axis, angle, scale); 
     }
 
     Quaternion quat() const {
@@ -604,5 +1309,23 @@ struct Basis {
             temp[k] = (elements[k][i] + elements[i][k]) * s;
         }
         return Quaternion(temp[0], temp[1], temp[2], temp[3]);
+    }
+
+    Quaternion opCast(T : Quaternion)() const {
+        return quat();
+    }
+
+    private void _setDiagonal(in Vector3 diag) {
+        rows[0][0] = diag.x;
+        rows[0][1] = 0;
+        rows[0][2] = 0;
+
+        rows[1][0] = 0;
+        rows[1][1] = diag.y;
+        rows[1][2] = 0;
+
+        rows[2][0] = 0;
+        rows[2][1] = 0;
+        rows[2][2] = diag.z;
     }
 }

--- a/src/godot/math.d
+++ b/src/godot/math.d
@@ -1,0 +1,136 @@
+/// Contains godot math functions that is not tied to any other types
+module godot.math;
+
+public import godot.api.types : real_t;
+
+import std.math;
+import std.traits;
+
+@nogc nothrow:
+
+
+enum real_t CMP_EPSILON = 0.00001;
+enum real_t CMP_EPSILON2 = (CMP_EPSILON * CMP_EPSILON);
+
+enum real_t _PLANE_EQ_DOT_EPSILON = 0.999;
+enum real_t _PLANE_EQ_D_EPSILON = 0.0001;
+
+// tolerate some more floating point error normally
+enum real_t UNIT_EPSILON = 0.001;
+
+
+pragma(inline, true)
+inout(T) fposmodp(T)(inout(T) x, inout(T) y) if (isFloatingPoint!T) {
+    T value = fmod(x, y);
+    if (value < 0) {
+        value += y;
+    }
+    value += 0.0f;
+    return value;
+}
+
+pragma(inline, true)
+inout(T) fposmod(T)(inout(T) x, inout(T) y) if (isFloatingPoint!T) {
+    T value = fmod(x, y);
+    if (((value < 0) && (y > 0)) || ((value > 0) && (y < 0))) {
+        value += y;
+    }
+    value += 0.0;
+    return value;
+}
+
+pragma(inline, true)
+T posmod(T)(T x, T y) if (isIntegral!T) {
+    assert(y != 0, "Division by zero in posmod is undefined.");
+    Unqual!T value = x % y;
+    if (((value < 0) && (y > 0)) || ((value > 0) && (y < 0))) {
+        value += y;
+    }
+    return value;
+}
+
+pragma(inline, true)
+T lerp(T)(T from, T to, T weight) if (isFloatingPoint!T) { 
+    return from + (to - from) * weight; 
+}
+
+pragma(inline, true)
+T cubicInterpolate(T)(T from, T to, T pre, T post, T weight) if (isFloatingPoint!T) {
+    return 0.5 *
+            ((from * 2.0) +
+                    (-pre + to) * weight +
+                    (2.0 * pre - 5.0 * from + 4.0 * to - post) * (weight * weight) +
+                    (-pre + 3.0 * from - 3.0 * to + post) * (weight * weight * weight));
+}
+
+pragma(inline, true)
+static T cubicInterpolateInTime(T)(T from, T to, T pre, T post, T weight,
+            T toT, T preT, T postT) if (isFloatingPoint!T) {
+        /* Barry-Goldman method */
+        T t = lerp(0.0, toT, weight);
+        T a1 = lerp(pre, from, preT == 0 ? 0.0 : (t - preT) / -preT); // ignore linter warning, arguments intended
+        T a2 = lerp(from, to, toT == 0 ? 0.5 : t / toT);
+        T a3 = lerp(to, post, postT - toT == 0 ? 1.0 : (t - toT) / (postT - toT)); // ignore linter warning
+        T b1 = lerp(a1, a2, toT - preT == 0 ? 0.0 : (t - preT) / (toT - preT));
+        T b2 = lerp(a2, a3, postT == 0 ? 1.0 : t / postT);
+        return lerp(b1, b2, toT == 0 ? 0.5 : t / toT);
+    }
+
+double deg2rad(double y) @nogc nothrow {
+    return y * PI / 180.0;
+}
+
+double rad2deg(double y) @nogc nothrow {
+    return y * 180.0 / PI;
+}
+
+double snapped(double value, double step) {
+    if (step != 0) {
+        value = floor(value / step + 0.5) * step;
+    }
+    return value;
+}
+
+T smoothstep(T)(T from, T to, T s) if (isFloatingPoint!T) {
+    if (isClose(from, to)) {
+        return from;
+    }
+    T s = clamp((s - from) / (to - from), 0.0, 1.0);
+    return s * s * (3.0 - 2.0 * s);
+}
+
+T wrapf(T)(T value, T min, T max) if (isFloatingPoint!T) {
+    float range = max - min;
+    if (isClose(range, 0)) {
+        return min;
+    }
+    float result = value - (range * floor((value - min) / range));
+    if (isClose(result, max)) {
+        return min;
+    }
+    return result;
+}
+
+double ease(double x, double c) {
+    if (x < 0) {
+        x = 0;
+    } else if (x > 1.0) {
+        x = 1.0;
+    }
+    if (c > 0) {
+        if (c < 1.0) {
+            return 1.0 - pow(1.0 - x, 1.0 / c);
+        } else {
+            return pow(x, c);
+        }
+    } else if (c < 0) {
+        //inout ease
+        if (x < 0.5) {
+            return pow(x * 2.0, -c) * 0.5;
+        } else {
+            return (1.0 - pow(1.0 - (x - 0.5) * 2.0, -c)) * 0.5 + 0.5;
+        }
+    } else {
+        return 0; // no ease (raw)
+    }
+}

--- a/src/godot/quat.d
+++ b/src/godot/quat.d
@@ -16,8 +16,11 @@ module godot.quat;
 import godot.api.types;
 import godot.vector3;
 import godot.basis;
+import godot.math;
+import godot.globalenums : EulerOrder;
 
 import std.math;
+import std.algorithm.comparison : clamp;
 
 /**
 A 4-dimensional vector representing a rotation.
@@ -31,27 +34,33 @@ It can be used to perform SLERP (spherical-linear interpolation) between two rot
 struct Quaternion {
 @nogc nothrow:
 
-    real_t x = 0;
-    real_t y = 0;
-    real_t z = 0;
-    real_t w = 1;
-
-    void set(real_t p_x, real_t p_y, real_t p_z, real_t p_w) {
-        x = p_x;
-        y = p_y;
-        z = p_z;
-        w = p_w;
+    union { 
+        struct {
+            real_t x = 0;
+            real_t y = 0;
+            real_t z = 0;
+            real_t w = 1;
+        }
+        real_t[4] components;
     }
 
-    this(real_t p_x, real_t p_y, real_t p_z, real_t p_w) {
-        x = p_x;
-        y = p_y;
-        z = p_z;
-        w = p_w;
+    void set(real_t x, real_t y, real_t z, real_t w) {
+        this.x = x;
+        this.y = y;
+        this.z = z;
+        this.w = w;
+    }
+
+    this(real_t x, real_t y, real_t z, real_t w) {
+        set(x,y,z,w);
     }
 
     real_t length() const {
         return sqrt(lengthSquared());
+    }
+
+    bool isEqualApprox(in Quaternion quaternion) const {
+	    return isClose(x, quaternion.x) && isClose(y, quaternion.y) && isClose(z, quaternion.z) && isClose(w, quaternion.w);
     }
 
     void normalize() {
@@ -62,14 +71,40 @@ struct Quaternion {
         return this / length();
     }
 
+    bool isNormalized() const {
+        return isClose(lengthSquared(), 1, UNIT_EPSILON); //use less epsilon
+    }
+
     Quaternion inverse() const {
         return Quaternion(-x, -y, -z, w);
     }
 
-    void setEuler(in Vector3 p_euler) {
-        real_t half_a1 = p_euler.x * 0.5;
-        real_t half_a2 = p_euler.y * 0.5;
-        real_t half_a3 = p_euler.z * 0.5;
+    Quaternion log() const {
+        Quaternion src = this;
+        Vector3 src_v = src.getAxis() * src.getAngle();
+        return Quaternion(src_v.x, src_v.y, src_v.z, 0);
+    }
+
+    Quaternion exp() const {
+        Quaternion src = this;
+        Vector3 src_v = Vector3(src.x, src.y, src.z);
+        real_t theta = src_v.length();
+        src_v = src_v.normalized();
+        if (theta < CMP_EPSILON || !src_v.isNormalized()) {
+            return Quaternion(0, 0, 0, 1);
+        }
+        return Quaternion(src_v, theta);
+    }
+
+    real_t angleTo(in Quaternion to) const {
+        real_t d = dot(to);
+        return acos(clamp(d * d * 2 - 1, -1, 1));
+    }
+
+    void setEuler(in Vector3 euler) {
+        real_t half_a1 = euler.x * 0.5;
+        real_t half_a2 = euler.y * 0.5;
+        real_t half_a3 = euler.z * 0.5;
 
         // R = X(a1).Y(a2).Z(a3) convention for Euler angles.
         // Conversion to quaternion as listed in https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19770024290.pdf (page A-2)
@@ -88,37 +123,31 @@ struct Quaternion {
             -sin_a1 * sin_a2 * sin_a3 + cos_a1 * cos_a2 * cos_a3);
     }
 
-    Quaternion slerp(in Quaternion q, in real_t t) const {
+    Quaternion slerp(in Quaternion to, in real_t weight) const {
         Quaternion to1;
         real_t omega, cosom, sinom, scale0, scale1;
         // calc cosine
-        cosom = dot(q);
+        cosom = dot(to);
 
         // adjust signs (if necessary)
         if (cosom < 0.0) {
             cosom = -cosom;
-            to1.x = -q.x;
-            to1.y = -q.y;
-            to1.z = -q.z;
-            to1.w = -q.w;
+            to1 = -to;
         } else {
-            to1.x = q.x;
-            to1.y = q.y;
-            to1.z = q.z;
-            to1.w = q.w;
+            to1 = to;
         }
         // calculate coefficients
         if ((1.0 - cosom) > CMP_EPSILON) {
             // standard case (slerp)
             omega = acos(cosom);
             sinom = sin(omega);
-            scale0 = sin((1.0 - t) * omega) / sinom;
-            scale1 = sin(t * omega) / sinom;
+            scale0 = sin((1.0 - weight) * omega) / sinom;
+            scale1 = sin(weight * omega) / sinom;
         } else {
             // "from" and "to" quaternions are very close
             //  ... so we can do a linear interpolation
-            scale0 = 1.0 - t;
-            scale1 = t;
+            scale0 = 1.0 - weight;
+            scale1 = weight;
         }
         // calculate final values
         return Quaternion(
@@ -129,38 +158,140 @@ struct Quaternion {
         );
     }
 
-    Quaternion slerpni(in Quaternion q, in real_t t) const {
+    Quaternion slerpni(in Quaternion to, in real_t weight) const {
         Quaternion from = this;
 
-        real_t dot = from.dot(q);
+        real_t dot = from.dot(to);
 
         if (fabs(dot) > 0.9999)
             return from;
 
         real_t theta = acos(dot),
         sinT = 1.0 / sin(theta),
-        newFactor = sin(t * theta) * sinT,
-        invFactor = sin((1.0 - t) * theta) * sinT;
+        newFactor = sin(weight * theta) * sinT,
+        invFactor = sin((1.0 - weight) * theta) * sinT;
 
-        return Quaternion(invFactor * from.x + newFactor * q.x,
-            invFactor * from.y + newFactor * q.y,
-            invFactor * from.z + newFactor * q.z,
-            invFactor * from.w + newFactor * q.w);
+        return Quaternion(invFactor * from.x + newFactor * to.x,
+            invFactor * from.y + newFactor * to.y,
+            invFactor * from.z + newFactor * to.z,
+            invFactor * from.w + newFactor * to.w);
     }
 
-    Quaternion cubicSlerp(in Quaternion q, in Quaternion prep, in Quaternion postq, in real_t t) const {
-        //the only way to do slerp :|
-        real_t t2 = (1.0 - t) * t * 2;
-        Quaternion sp = this.slerp(q, t);
-        Quaternion sq = prep.slerpni(postq, t);
-        return sp.slerpni(sq, t2);
+    alias sphericalCubicInterpolate = cubicSlerp;
+    Quaternion cubicSlerp(in Quaternion b, in Quaternion preA, in Quaternion postB, in real_t weight) const {
+        // assert(isNormalized(), "start quaternion must be normalized");
+        // assert(b.isNormalized(), "end quaternion must be normalized");
+        Quaternion from_q = this;
+        Quaternion pre_q = preA;
+        Quaternion to_q = b;
+        Quaternion post_q = postB;
+
+        // Align flip phases.
+        from_q = Basis(from_q).getRotationQuaternion();
+        pre_q = Basis(pre_q).getRotationQuaternion();
+        to_q = Basis(to_q).getRotationQuaternion();
+        post_q = Basis(post_q).getRotationQuaternion();
+
+        // Flip quaternions to shortest path if necessary.
+        bool flip1 = sgn(from_q.dot(pre_q)) > 0;
+        pre_q = flip1 ? -pre_q : pre_q;
+        bool flip2 = sgn(from_q.dot(to_q)) > 0;
+        to_q = flip2 ? -to_q : to_q;
+        bool flip3 = flip2 ? to_q.dot(post_q) <= 0 : sgn(to_q.dot(post_q)) > 0;
+        post_q = flip3 ? -post_q : post_q;
+
+        // Calc by Expmap in from_q space.
+        Quaternion ln_from = Quaternion(0, 0, 0, 0);
+        Quaternion ln_to = (from_q.inverse() * to_q).log();
+        Quaternion ln_pre = (from_q.inverse() * pre_q).log();
+        Quaternion ln_post = (from_q.inverse() * post_q).log();
+        Quaternion ln = Quaternion(0, 0, 0, 0);
+        ln.x = cubicInterpolate(ln_from.x, ln_to.x, ln_pre.x, ln_post.x, weight);
+        ln.y = cubicInterpolate(ln_from.y, ln_to.y, ln_pre.y, ln_post.y, weight);
+        ln.z = cubicInterpolate(ln_from.z, ln_to.z, ln_pre.z, ln_post.z, weight);
+        Quaternion q1 = from_q * ln.exp();
+
+        // Calc by Expmap in to_q space.
+        ln_from = (to_q.inverse() * from_q).log();
+        ln_to = Quaternion(0, 0, 0, 0);
+        ln_pre = (to_q.inverse() * pre_q).log();
+        ln_post = (to_q.inverse() * post_q).log();
+        ln = Quaternion(0, 0, 0, 0);
+        ln.x = cubicInterpolate(ln_from.x, ln_to.x, ln_pre.x, ln_post.x, weight);
+        ln.y = cubicInterpolate(ln_from.y, ln_to.y, ln_pre.y, ln_post.y, weight);
+        ln.z = cubicInterpolate(ln_from.z, ln_to.z, ln_pre.z, ln_post.z, weight);
+        Quaternion q2 = to_q * ln.exp();
+
+        // To cancel error made by Expmap ambiguity, do blends.
+        return q1.slerp(q2, weight);
     }
 
-    void getAxisAndAngle(out Vector3 r_axis, out real_t r_angle) const {
-        r_angle = 2 * acos(w);
-        r_axis.x = x / sqrt(1 - w * w);
-        r_axis.y = y / sqrt(1 - w * w);
-        r_axis.z = z / sqrt(1 - w * w);
+     Quaternion sphericalCubicInterpolateInTime(in Quaternion b, in Quaternion preA, in Quaternion postB, in real_t weight,
+            in real_t bT, in real_t preAT, in real_t postBT) const {
+        // assert(isNormalized(), "start quaternion must be normalized");
+        // assert(b.isNormalized(), "end quaternion must be normalized");
+        Quaternion from_q = this;
+        Quaternion pre_q = preA;
+        Quaternion to_q = b;
+        Quaternion post_q = postB;
+
+        // Align flip phases.
+        from_q = Basis(from_q).getRotationQuaternion();
+        pre_q = Basis(pre_q).getRotationQuaternion();
+        to_q = Basis(to_q).getRotationQuaternion();
+        post_q = Basis(post_q).getRotationQuaternion();
+
+        // Flip quaternions to shortest path if necessary.
+        bool flip1 = sgn(from_q.dot(pre_q)) > 0;
+        pre_q = flip1 ? -pre_q : pre_q;
+        bool flip2 = sgn(from_q.dot(to_q)) > 0;
+        to_q = flip2 ? -to_q : to_q;
+        bool flip3 = flip2 ? to_q.dot(post_q) <= 0 : sgn(to_q.dot(post_q)) > 0;
+        post_q = flip3 ? -post_q : post_q;
+
+        // Calc by Expmap in from_q space.
+        Quaternion ln_from = Quaternion(0, 0, 0, 0);
+        Quaternion ln_to = (from_q.inverse() * to_q).log();
+        Quaternion ln_pre = (from_q.inverse() * pre_q).log();
+        Quaternion ln_post = (from_q.inverse() * post_q).log();
+        Quaternion ln = Quaternion(0, 0, 0, 0);
+        ln.x = cubicInterpolateInTime(ln_from.x, ln_to.x, ln_pre.x, ln_post.x, weight, bT, preAT, postBT);
+        ln.y = cubicInterpolateInTime(ln_from.y, ln_to.y, ln_pre.y, ln_post.y, weight, bT, preAT, postBT);
+        ln.z = cubicInterpolateInTime(ln_from.z, ln_to.z, ln_pre.z, ln_post.z, weight, bT, preAT, postBT);
+        Quaternion q1 = from_q * ln.exp();
+
+        // Calc by Expmap in to_q space.
+        ln_from = (to_q.inverse() * from_q).log();
+        ln_to = Quaternion(0, 0, 0, 0);
+        ln_pre = (to_q.inverse() * pre_q).log();
+        ln_post = (to_q.inverse() * post_q).log();
+        ln = Quaternion(0, 0, 0, 0);
+        ln.x = cubicInterpolateInTime(ln_from.x, ln_to.x, ln_pre.x, ln_post.x, weight, bT, preAT, postBT);
+        ln.y = cubicInterpolateInTime(ln_from.y, ln_to.y, ln_pre.y, ln_post.y, weight, bT, preAT, postBT);
+        ln.z = cubicInterpolateInTime(ln_from.z, ln_to.z, ln_pre.z, ln_post.z, weight, bT, preAT, postBT);
+        Quaternion q2 = to_q * ln.exp();
+
+        // To cancel error made by Expmap ambiguity, do blends.
+        return q1.slerp(q2, weight);
+    }
+
+    Vector3 getAxis() const {
+        if (fabs(w) > 1 - CMP_EPSILON) {
+            return Vector3(x, y, z);
+        }
+        real_t r = (cast(real_t)1) / sqrt(1 - w * w);
+        return Vector3(x * r, y * r, z * r);
+    }
+
+    real_t getAngle() const {
+        return 2 * acos(w);
+    }
+
+    void getAxisAndAngle(out Vector3 axis, out real_t angle) const {
+        angle = 2 * acos(w);
+        axis.x = x / sqrt(1.0 - w * w);
+        axis.y = y / sqrt(1.0 - w * w);
+        axis.z = z / sqrt(1.0 - w * w);
     }
 
     Quaternion opBinary(string op : "*")(in Vector3 v) const {
@@ -170,11 +301,23 @@ struct Quaternion {
             -x * v.x - y * v.y - z * v.z);
     }
 
-    Vector3 xform(in Vector3 v) const {
-        Quaternion q = this * v;
-        q *= this.inverse();
-        return Vector3(q.x, q.y, q.z);
+    ref real_t opIndex(size_t index) {
+        return components[index];
     }
+
+    real_t opIndex(size_t index) const {
+        return components[index];
+    }
+
+    Vector3 xform(in Vector3 v) const {
+        Vector3 u = Vector3(x, y, z);
+		Vector3 uv = u.cross(v);
+		return v + ((uv * w) + u.cross(uv)) * 2.0;
+    }
+
+    Vector3 xformInv(in Vector3 v) const {
+		return inverse().xform(v);
+	}
 
     this(in Vector3 axis, in real_t angle) {
         real_t d = axis.length();
@@ -208,6 +351,29 @@ struct Quaternion {
             z = c.z * rs;
             w = s * 0.5;
         }
+    }
+
+    // same as Quaternion.fromEuler
+    this(in Vector3 eulerYXZ) {
+        real_t half_a1 = eulerYXZ.y * 0.5f;
+        real_t half_a2 = eulerYXZ.x * 0.5f;
+        real_t half_a3 = eulerYXZ.z * 0.5f;
+
+        // R = Y(a1).X(a2).Z(a3) convention for Euler angles.
+        // Conversion to quaternion as listed in https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19770024290.pdf (page A-6)
+        // a3 is the angle of the first rotation, following the notation in this reference.
+
+        real_t cos_a1 = cos(half_a1);
+        real_t sin_a1 = sin(half_a1);
+        real_t cos_a2 = cos(half_a2);
+        real_t sin_a2 = sin(half_a2);
+        real_t cos_a3 = cos(half_a3);
+        real_t sin_a3 = sin(half_a3);
+
+        x = sin_a1 * cos_a2 * sin_a3 + cos_a1 * sin_a2 * cos_a3;
+        y = sin_a1 * cos_a2 * cos_a3 - cos_a1 * sin_a2 * sin_a3;
+        z = -sin_a1 * sin_a2 * cos_a3 + cos_a1 * cos_a2 * sin_a3;
+        w = sin_a1 * sin_a2 * sin_a3 + cos_a1 * cos_a2 * cos_a3;
     }
 
     real_t dot(in Quaternion q) const {
@@ -279,7 +445,17 @@ struct Quaternion {
     }
 
     Vector3 getEuler() const {
-        Basis m = Basis(this);
-        return m.getEuler();
+        return getEulerYxz();
     }
+
+    Vector3 getEulerXyz() const {
+        Basis m = Basis(this);
+	    return m.getEuler(EulerOrder.eulerOrderXyz);
+    }
+
+	Vector3 getEulerYxz() const {
+        Basis m = Basis(this);
+	    return m.getEuler(EulerOrder.eulerOrderYxz);
+    }
+
 }

--- a/src/godot/transform2d.d
+++ b/src/godot/transform2d.d
@@ -16,6 +16,7 @@ module godot.transform2d;
 import godot.api.types;
 import godot.vector2;
 import godot.rect2;
+import godot.poolarrays;
 
 import std.math;
 import std.algorithm.comparison;
@@ -25,7 +26,17 @@ import std.algorithm.mutation : swap;
 Represents one or many transformations in 2D space such as translation, rotation, or scaling. It is similar to a 3x2 matrix.
 */
 struct Transform2D {
-@nogc nothrow:
+//@nogc nothrow:
+    // Warning #1: basis of Transform2D is stored differently from Basis. In terms of columns array, the basis matrix looks like "on paper":
+	// M = (columns[0][0] columns[1][0])
+	//     (columns[0][1] columns[1][1])
+	// This is such that the columns, which can be interpreted as basis vectors of the coordinate system "painted" on the object, can be accessed as columns[i].
+	// Note that this is the opposite of the indices in mathematical texts, meaning: $M_{12}$ in a math book corresponds to columns[1][0] here.
+	// This requires additional care when working with explicit indices.
+	// See https://en.wikipedia.org/wiki/Row-_and_column-major_order for further reading.
+
+	// Warning #2: 2D be aware that unlike 3D code, 2D code uses a left-handed coordinate system: Y-axis points down,
+	// and angle is measure from +X to +Y in a clockwise-fashion.
 
     union {
         Vector2[3] columns = [Vector2(1, 0), Vector2(0, 1), Vector2(0, 0)];
@@ -36,11 +47,11 @@ struct Transform2D {
         }
     }
 
-    real_t tdotx(in Vector2 v) const {
+    real_t tdotx(in Vector2 v) const @nogc nothrow {
         return columns[0][0] * v.x + columns[1][0] * v.y;
     }
 
-    real_t tdoty(in Vector2 v) const {
+    real_t tdoty(in Vector2 v) const @nogc nothrow {
         return columns[0][1] * v.x + columns[1][1] * v.y;
     }
 
@@ -53,12 +64,36 @@ struct Transform2D {
         columns[2][1] = oy;
     }
 
-    const(Vector2) opIndex(int axis) const {
-        return columns[axis];
+    this(in Vector2 x, in Vector2 y, in Vector2 origin) {
+        columns[0] = x;
+        columns[1] = y;
+        columns[2] = origin;
     }
 
-    ref Vector2 opIndex(int axis) return {
-        return columns[axis];
+    this(real_t rot, in Vector2 pos) {
+        real_t cr = cos(rot);
+        real_t sr = sin(rot);
+        columns[0][0] = cr;
+        columns[0][1] = sr;
+        columns[1][0] = -sr;
+        columns[1][1] = cr;
+        columns[2] = pos;
+    }
+
+    this(in real_t rot, in Vector2 scale, in real_t skew, in Vector2 pos) {
+        columns[0][0] = cos(rot) * scale.x;
+        columns[1][1] = cos(rot + skew) * scale.y;
+        columns[1][0] = -sin(rot + skew) * scale.y;
+        columns[0][1] = sin(rot) * scale.x;
+        columns[2] = pos;
+    }
+
+    const(Vector2) opIndex(int col) const {
+        return columns[col];
+    }
+
+    ref Vector2 opIndex(int col) return {
+        return columns[col];
     }
 
     Vector2 basisXform(in Vector2 v) const {
@@ -75,15 +110,15 @@ struct Transform2D {
         );
     }
 
-    Vector2 xform(in Vector2 v) const {
+    Vector2 xform(in Vector2 v) const @nogc nothrow {
         return Vector2(
             tdotx(v),
             tdoty(v)
         ) + columns[2];
     }
 
-    Vector2 xformInv(in Vector2 p_vec) const {
-        Vector2 v = p_vec - columns[2];
+    Vector2 xformInv(in Vector2 vec) const {
+        Vector2 v = vec - columns[2];
 
         return Vector2(
             columns[0].dot(v),
@@ -91,10 +126,10 @@ struct Transform2D {
         );
     }
 
-    Rect2 xform(in Rect2 p_rect) const {
-        Vector2 x = columns[0] * p_rect.size.x;
-        Vector2 y = columns[1] * p_rect.size.y;
-        Vector2 pos = xform(p_rect.position);
+    Rect2 xform(in Rect2 rect) const {
+        Vector2 x = columns[0] * rect.size.x;
+        Vector2 y = columns[1] * rect.size.y;
+        Vector2 pos = xform(rect.position);
 
         Rect2 new_rect;
         new_rect.position = pos;
@@ -104,20 +139,46 @@ struct Transform2D {
         return new_rect;
     }
 
-    void setRotationAndScale(real_t p_rot, in Vector2 p_scale) {
-        columns[0][0] = cos(p_rot) * p_scale.x;
-        columns[1][1] = cos(p_rot) * p_scale.y;
-        columns[1][0] = -sin(p_rot) * p_scale.y;
-        columns[0][1] = sin(p_rot) * p_scale.x;
+    PackedVector2Array xform(ref const(PackedVector2Array) array) const {
+        PackedVector2Array newArray;
+        newArray.resize(array.size());
 
+        for (int i = 0; i < array.size(); ++i) {
+            newArray[i] = xform(array[i]);
+        }
+        return newArray;
     }
 
-    Rect2 xformInv(in Rect2 p_rect) const {
+    PackedVector2Array xformInv(ref const (PackedVector2Array) array) const {
+        PackedVector2Array newArray;
+        newArray.resize(array.size());
+
+        for (int i = 0; i < array.size(); ++i) {
+            newArray[i] = xformInv(array[i]);
+        }
+        return newArray;
+    }
+
+    void setRotationAndScale(real_t rot, in Vector2 scale) {
+        columns[0][0] = cos(rot) * scale.x;
+        columns[1][1] = cos(rot) * scale.y;
+        columns[1][0] = -sin(rot) * scale.y;
+        columns[0][1] = sin(rot) * scale.x;
+    }
+
+    void setRotationScaleAndSkew(in real_t rot, in Vector2 scale, in real_t skew) {
+        columns[0][0] = cos(rot) * scale.x;
+        columns[1][1] = cos(rot + skew) * scale.y;
+        columns[1][0] = -sin(rot + skew) * scale.y;
+        columns[0][1] = sin(rot) * scale.x;
+    }
+
+    Rect2 xformInv(in Rect2 rect) const {
         Vector2[4] ends = [
-            xformInv(p_rect.position),
-            xformInv(Vector2(p_rect.position.x, p_rect.position.y + p_rect.size.y)),
-            xformInv(Vector2(p_rect.position.x + p_rect.size.x, p_rect.position.y + p_rect.size.y)),
-            xformInv(Vector2(p_rect.position.x + p_rect.size.x, p_rect.position.y))
+            xformInv(rect.position),
+            xformInv(Vector2(rect.position.x, rect.position.y + rect.size.y)),
+            xformInv(Vector2(rect.position.x + rect.size.x, rect.position.y + rect.size.y)),
+            xformInv(Vector2(rect.position.x + rect.size.x, rect.position.y))
         ];
 
         Rect2 new_rect;
@@ -162,8 +223,18 @@ struct Transform2D {
         return inv;
     }
 
-    void rotate(real_t p_phi) {
-        this = Transform2D(p_phi, Vector2()) * (this);
+    real_t getSkew() const {
+        real_t det = basisDeterminant();
+	    return acos(columns[0].normalized().dot(sgn(det) * columns[1].normalized())) - PI * 0.5f;
+    }
+
+    void setSkew(in real_t angle) {
+        real_t det = basisDeterminant();
+        columns[1] = sgn(det) * columns[0].rotated((PI * 0.5f + angle)).normalized() * columns[1].length();
+    }
+
+    void rotate(in real_t angle) {
+        this = Transform2D(angle, Vector2()) * (this);
     }
 
     real_t getRotation() const {
@@ -175,23 +246,13 @@ struct Transform2D {
         return atan2(m[0].y, m[0].x);
     }
 
-    void setRotation(real_t p_rot) {
-        real_t cr = cos(p_rot);
-        real_t sr = sin(p_rot);
+    void setRotation(real_t rot) {
+        real_t cr = cos(rot);
+        real_t sr = sin(rot);
         columns[0][0] = cr;
         columns[0][1] = sr;
         columns[1][0] = -sr;
         columns[1][1] = cr;
-    }
-
-    this(real_t p_rot, in Vector2 p_pos) {
-        real_t cr = cos(p_rot);
-        real_t sr = sin(p_rot);
-        columns[0][0] = cr;
-        columns[0][1] = sr;
-        columns[1][0] = -sr;
-        columns[1][1] = cr;
-        columns[2] = p_pos;
     }
 
     Vector2 getScale() const {
@@ -199,25 +260,32 @@ struct Transform2D {
         return det_sign * Vector2(columns[0].length(), columns[1].length());
     }
 
-    void scale(in Vector2 p_scale) {
-        scaleBasis(p_scale);
-        columns[2] *= p_scale;
+    void setScale(in Vector2 scale) {
+        columns[0].normalize();
+        columns[1].normalize();
+        columns[0] *= scale.x;
+        columns[1] *= scale.y;
     }
 
-    void scaleBasis(in Vector2 p_scale) {
-        columns[0][0] *= p_scale.x;
-        columns[0][1] *= p_scale.y;
-        columns[1][0] *= p_scale.x;
-        columns[1][1] *= p_scale.y;
+    void scale(in Vector2 scale) {
+        scaleBasis(scale);
+        columns[2] *= scale;
+    }
+
+    void scaleBasis(in Vector2 scale) {
+        columns[0][0] *= scale.x;
+        columns[0][1] *= scale.y;
+        columns[1][0] *= scale.x;
+        columns[1][1] *= scale.y;
 
     }
 
-    void translate(real_t p_tx, real_t p_ty) {
-        translate(Vector2(p_tx, p_ty));
+    Vector2 getOrigin() const { 
+        return columns[2]; 
     }
 
-    void translate(in Vector2 p_translation) {
-        columns[2] += basisXform(p_translation);
+    void setOrigin(in Vector2 origin) {
+        columns[2] = origin;
     }
 
     void orthonormalize() {
@@ -238,18 +306,40 @@ struct Transform2D {
         Transform2D on = this;
         on.orthonormalize();
         return on;
-
     }
 
-    void opOpAssign(string op : "*")(in Transform2D p_transform) {
-        columns[2] = xform(p_transform.columns[2]);
+    bool isEqualApprox(in Transform2D transform) const {
+        return columns[0].isEqualApprox(transform.columns[0]) 
+            && columns[1].isEqualApprox(transform.columns[1]) 
+            && columns[2].isEqualApprox(transform.columns[2]);
+    }
+
+    Transform2D lookingAt(in Vector2 target) const {
+        Transform2D return_trans = Transform2D(getRotation(), getOrigin());
+        Vector2 target_position = affineInverse().xform(target);
+        return_trans.setRotation(return_trans.getRotation() + (target_position * getScale()).angle());
+        return return_trans;       
+    }
+
+    bool opEquals(in Transform2D transform) const {
+        foreach (i; 0..columns.length) {
+            if (columns[i] != transform.columns[i]) {
+                return false;
+            }
+        }
+
+	    return true;
+    }
+
+    void opOpAssign(string op : "*")(in Transform2D transform) {
+        columns[2] = xform(transform.columns[2]);
 
         real_t x0, x1, y0, y1;
 
-        x0 = tdotx(p_transform.columns[0]);
-        x1 = tdoty(p_transform.columns[0]);
-        y0 = tdotx(p_transform.columns[1]);
-        y1 = tdoty(p_transform.columns[1]);
+        x0 = tdotx(transform.columns[0]);
+        x1 = tdoty(transform.columns[0]);
+        y0 = tdotx(transform.columns[1]);
+        y1 = tdoty(transform.columns[1]);
 
         columns[0][0] = x0;
         columns[0][1] = x1;
@@ -257,25 +347,40 @@ struct Transform2D {
         columns[1][1] = y1;
     }
 
-    Transform2D opBinary(string op : "*")(in Transform2D p_transform) const {
+    Transform2D opBinary(string op : "*")(in Transform2D transform) const {
         Transform2D t = this;
-        t *= p_transform;
+        t *= transform;
         return t;
 
     }
 
-    Transform2D scaled(in Vector2 p_scale) const {
-        Transform2D copy = this;
-        copy.scale(p_scale);
-        return copy;
-
+    void opOpAssign(string op : "*")(in real_t value) {
+        columns[0] *= value;
+        columns[1] *= value;
+        columns[2] *= value;
     }
 
-    Transform2D basisScaled(in Vector2 p_scale) const {
-        Transform2D copy = this;
-        copy.scaleBasis(p_scale);
-        return copy;
+    Transform2D opBinary(string op : "*")(in real_t value) const {
+        Transform2D ret = Transform2D(this);
+        ret *= value;
+        return ret;
+    }
 
+    Transform2D scaled(in Vector2 scale) const {
+        Transform2D copy = this;
+        copy.scale(scale);
+        return copy;
+    }
+
+    Transform2D scaledLocal(in Vector2 scale) const {
+        // Equivalent to right multiplication
+        return Transform2D(columns[0] * scale.x, columns[1] * scale.y, columns[2]);
+    }
+
+    Transform2D basisScaled(in Vector2 scale) const {
+        Transform2D copy = this;
+        copy.scaleBasis(scale);
+        return copy;
     }
 
     Transform2D untranslated() const {
@@ -284,33 +389,51 @@ struct Transform2D {
         return copy;
     }
 
-    Transform2D translated(in Vector2 p_offset) const {
-        Transform2D copy = this;
-        copy.translate(p_offset);
-        return copy;
+    Transform2D translated(in Vector2 offset) const {
+        // Equivalent to left multiplication
+	    return Transform2D(columns[0], columns[1], columns[2] + offset);
     }
 
-    Transform2D rotated(real_t p_phi) const {
-        Transform2D copy = this;
-        copy.rotate(p_phi);
-        return copy;
+    Transform2D translatedLocal(in Vector2 offset) const {
+        // Equivalent to right multiplication
+        return Transform2D(columns[0], columns[1], columns[2] + basisXform(offset));
+    }
 
+    deprecated("use translateLocal")
+    alias translate = translateLocal;
+
+    void translateLocal(real_t tx, real_t ty) {
+        translateLocal(Vector2(tx, ty));
+    }
+
+    void translateLocal(in Vector2 translation) {
+        columns[2] += basisXform(translation);
+    }
+
+    Transform2D rotated(real_t angle) const {
+        // Equivalent to left multiplication
+        return Transform2D(angle, Vector2()) * (this);
+    }
+
+    Transform2D rotatedLocal(const real_t angle) const {
+        // Equivalent to right multiplication
+        return (this) * Transform2D(angle, Vector2()); // Could be optimized, because origin transform can be skipped.
     }
 
     real_t basisDeterminant() const {
         return columns[0].x * columns[1].y - columns[0].y * columns[1].x;
     }
 
-    Transform2D interpolateWith(in Transform2D p_transform, real_t p_c) const {
+    Transform2D interpolateWith(in Transform2D transform, real_t c) const {
         //extract parameters
         Vector2 p1 = origin;
-        Vector2 p2 = p_transform.origin;
+        Vector2 p2 = transform.origin;
 
         real_t r1 = getRotation();
-        real_t r2 = p_transform.getRotation();
+        real_t r2 = transform.getRotation();
 
         Vector2 s1 = getScale();
-        Vector2 s2 = p_transform.getScale();
+        Vector2 s2 = transform.getScale();
 
         //slerp rotation
         Vector2 v1 = Vector2(cos(r1), sin(r1));
@@ -318,21 +441,21 @@ struct Transform2D {
 
         real_t dot = v1.dot(v2);
 
-        dot = (dot < -1.0) ? -1.0 : ((dot > 1.0) ? 1.0 : dot); //clamp dot to [-1,1]
+        dot = clamp(dot, -1.0, 1.0);
 
         Vector2 v;
 
         if (dot > 0.9995) {
-            v = Vector2.linearInterpolate(v1, v2, p_c).normalized(); //linearly interpolate to avoid numerical precision issues
+            v = v1.linearInterpolate(v2, c).normalized(); //linearly interpolate to avoid numerical precision issues
         } else {
-            real_t angle = p_c * acos(dot);
+            real_t angle = c * acos(dot);
             Vector2 v3 = (v2 - v1 * dot).normalized();
             v = v1 * cos(angle) + v3 * sin(angle);
         }
 
         //construct matrix
-        Transform2D res = Transform2D(atan2(v.y, v.x), Vector2.linearInterpolate(p1, p2, p_c));
-        res.scaleBasis(Vector2.linearInterpolate(s1, s2, p_c));
+        Transform2D res = Transform2D(v.angle, p1.linearInterpolate(p2, c));
+        res.scaleBasis(s1.linearInterpolate(s2, c));
         return res;
     }
 }

--- a/src/godot/vector2.d
+++ b/src/godot/vector2.d
@@ -15,10 +15,16 @@ module godot.vector2;
 
 import godot.abi.core;
 import godot.abi.types;
+import godot.math;
+import godot.api.types;
 
-
+alias Size2 = Vector2;
+alias Point2 = Vector2;
+alias Size2i = Vector2i;
+alias Point2i = Vector2i;
 
 import std.math;
+import std.algorithm.comparison;
 
 private bool isValidSwizzle(dstring s) {
     import std.algorithm : canFind;
@@ -37,6 +43,11 @@ private bool isValidSwizzle(dstring s) {
 */
 struct Vector2 {
 @nogc nothrow:
+
+    enum Axis {
+        x,
+        y
+    }
 
     union {
         struct {
@@ -126,6 +137,21 @@ struct Vector2 {
         return axis ? y : x;
     }
 
+    Vector2.Axis minAxisIndex() const {
+		return x < y ? Axis.x : Axis.y;
+	}
+
+	Vector2.Axis maxAxisIndex() const {
+		return x < y ? Axis.y : Axis.x;
+	}
+
+    int opCmp(in Vector2 other) const {
+        import std.algorithm.comparison;
+        import std.range;
+
+        return cmp(only(x, y), only(other.x, other.y));
+    }
+
     Vector2 opBinary(string op)(in Vector2 other) const
     if (op == "+" || op == "-" || op == "*" || op == "/") {
         Vector2 ret;
@@ -165,11 +191,16 @@ struct Vector2 {
         y = mixin("y " ~ op ~ " scalar");
     }
 
-    int opCmp(in Vector2 other) const {
-        import std.algorithm.comparison;
-        import std.range;
+    bool opEquals(in Vector2 other) const {
+        return x == other.x && y == other.y;
+    }
 
-        return cmp(only(x, y), only(other.x, other.y));
+    bool isEqualApprox(in Vector2 v) const {
+        return isClose(x, v.x) && isClose(y, v.y);
+    }
+
+    bool isZeroApprox() const {
+        return isClose(x, 0) && isClose(y, 0);
     }
 
     real_t aspect() const {
@@ -191,12 +222,36 @@ struct Vector2 {
         return v;
     }
 
+    bool isNormalized() const {
+        // use length_squared() instead of length() to avoid sqrt(), makes it more stringent.
+        return isClose(lengthSquared(), 1, UNIT_EPSILON);
+    }
+
     real_t length() const {
         return sqrt(x * x + y * y);
     }
 
     real_t lengthSquared() const {
         return x * x + y * y;
+    }
+
+    Vector2 limitLength(in real_t p_len = 1.0) const {
+        const real_t l = length();
+        Vector2 v = this;
+        if (l > 0 && p_len < l) {
+            v /= l;
+            v *= p_len;
+        }
+
+        return v;
+    }
+
+    Vector2 min(in Vector2 p_vector2) const {
+        return Vector2(.min(x, p_vector2.x), .min(y, p_vector2.y));
+    }
+
+    Vector2 max(in Vector2 p_vector2) const {
+        return Vector2(.max(x, p_vector2.x), .max(y, p_vector2.y));
     }
 
     real_t distanceTo(in Vector2 p_vector2) const {
@@ -212,7 +267,13 @@ struct Vector2 {
     }
 
     real_t angleToPoint(in Vector2 p_vector2) const {
-        return atan2(y - p_vector2.y, x - p_vector2.x);
+        return (p_vector2 - this).angle();
+    }
+
+    Vector2 directionTo(in Vector2 p_to) const {
+        Vector2 ret = Vector2(p_to.x - x, p_to.y - y);
+        ret.normalize();
+        return ret;
     }
 
     real_t dot(in Vector2 p_other) const {
@@ -223,20 +284,32 @@ struct Vector2 {
         return x * p_other.y - y * p_other.x;
     }
 
+    Vector2 posmod(in real_t p_mod) const {
+        return Vector2(fposmod(x, p_mod), fposmod(y, p_mod));
+    }
+
+	Vector2 posmodv(in Vector2 p_modv) const {
+        return Vector2(fposmod(x, p_modv.x), fposmod(y, p_modv.y));
+    }
+
+	Vector2 project(in Vector2 p_to) const {
+        return p_to * (dot(p_to) / p_to.lengthSquared());
+    }
+
+    Vector2 planeProject(in real_t d, in Vector2 vec) const {
+        return vec - this * (dot(vec) - d);
+    }
+
+    deprecated
     Vector2 cross(real_t p_other) const {
         return Vector2(p_other * y, -p_other * x);
     }
 
-    Vector2 project(in Vector2 p_vec) const {
-        Vector2 v1 = p_vec;
-        Vector2 v2 = this;
-        return v2 * (v1.dot(v2) / v2.dot(v2));
+    Vector2 sign() const {
+        return Vector2(sgn(x), sgn(y));
     }
 
-    Vector2 planeProject(real_t p_d, in Vector2 p_vec) const {
-        return p_vec - this * (dot(p_vec) - p_d);
-    }
-
+    deprecated("use limitLength()")
     Vector2 clamped(real_t p_len) const {
         real_t l = length();
         Vector2 v = this;
@@ -262,39 +335,79 @@ struct Vector2 {
 
     }
 
+    // Superbelko: godot 4 uses lerp now, not sure if it is worth to keep old name
     alias lerp = linearInterpolate;
 
+    Vector2 slerp(in Vector2 p_to, const real_t p_weight) const {
+        real_t start_length_sq = lengthSquared();
+        real_t end_length_sq = p_to.lengthSquared();
+        if (start_length_sq == 0.0f || end_length_sq == 0.0f) {
+            // Zero length vectors have no angle, so the best we can do is either lerp or throw an error.
+            return lerp(p_to, p_weight);
+        }
+        real_t start_length = sqrt(start_length_sq);
+        real_t result_length = .lerp(start_length, sqrt(end_length_sq), p_weight);
+        real_t angle = angleTo(p_to);
+        return rotated(angle * p_weight) * (result_length / start_length);
+    }
+
     Vector2 cubicInterpolate(in Vector2 p_b, in Vector2 p_pre_a, in Vector2 p_post_b, real_t p_t) const {
-        Vector2 p0 = p_pre_a;
-        Vector2 p1 = this;
-        Vector2 p2 = p_b;
-        Vector2 p3 = p_post_b;
-
-        real_t t = p_t;
-        real_t t2 = t * t;
-        real_t t3 = t2 * t;
-
-        Vector2 ret;
-        ret = ((p1 * 2.0) +
-                (-p0 + p2) * t +
-                (p0 * 2.0 - p1 * 5.0 + p2 * 4 - p3) * t2 +
-                (-p0 + p1 * 3.0 - p2 * 3.0 + p3) * t3) * 0.5;
-
-        return ret;
+        Vector2 res = this;
+        res.x = .cubicInterpolate(res.x, p_b.x, p_pre_a.x, p_post_b.x, p_t);
+        res.y = .cubicInterpolate(res.y, p_b.y, p_pre_a.y, p_post_b.y, p_t);
+        return res;
     }
 
-    Vector2 slide(in Vector2 p_vec) const {
-        return p_vec - this * this.dot(p_vec);
+    Vector2 cubicInterpolateInTime(in Vector2 p_b, in Vector2 p_pre_a, in Vector2 p_post_b, in real_t p_weight, in real_t p_b_t, in real_t p_pre_a_t, in real_t p_post_b_t) const {
+        Vector2 res = this;
+        res.x = .cubicInterpolateInTime(res.x, p_b.x, p_pre_a.x, p_post_b.x, p_weight, p_b_t, p_pre_a_t, p_post_b_t);
+        res.y = .cubicInterpolateInTime(res.y, p_b.y, p_pre_a.y, p_post_b.y, p_weight, p_b_t, p_pre_a_t, p_post_b_t);
+        return res;
     }
 
-    Vector2 reflect(in Vector2 p_vec) const {
-        return p_vec - this * this.dot(p_vec) * 2.0;
+    Vector2 bezierInterpolate(in Vector2 p_control_1, in Vector2 p_control_2, in Vector2 p_end, in real_t p_t) const {
+        Vector2 res = this;
+
+        /* Formula from Wikipedia article on Bezier curves. */
+        real_t omt = (1.0 - p_t);
+        real_t omt2 = omt * omt;
+        real_t omt3 = omt2 * omt;
+        real_t t2 = p_t * p_t;
+        real_t t3 = t2 * p_t;
+
+        return res * omt3 + p_control_1 * omt2 * p_t * 3.0 + p_control_2 * omt * t2 * 3.0 + p_end * t3;
+    }
+
+    Vector2 moveToward(in Vector2 p_to, in real_t p_delta) const {
+        Vector2 v = this;
+        Vector2 vd = p_to - v;
+        real_t len = vd.length();
+        if (len <= p_delta || len < CMP_EPSILON)
+            return p_to;
+        return (v + vd / len * p_delta);
+    }
+
+    Vector2 slide(in Vector2 normal) const {
+        return this - normal * this.dot(normal);
+    }
+
+    Vector2 bounce(in Vector2 normal) const {
+        return -reflect(normal);
+    }
+
+    Vector2 reflect(in Vector2 normal) const {
+        return 2.0f * normal * dot(normal) - this;
     }
 
     real_t angle() const {
         return atan2(y, x);
     }
 
+    static Vector2 fromAngle(in real_t angle) {
+        return Vector2(cos(angle), sin(angle));
+    }
+
+    deprecated("use Vector2.fromAngle()")
     void setRotation(real_t p_radians) {
         x = cos(p_radians);
         y = sin(p_radians);
@@ -304,12 +417,17 @@ struct Vector2 {
         return Vector2(fabs(x), fabs(y));
     }
 
-    Vector2 rotated(real_t p_by) const {
-        Vector2 v = void;
-        v.setRotation(angle() + p_by);
-        v *= length();
-        return v;
+    Vector2 rotated(real_t by) const {
+        real_t sine = sin(by);
+        real_t cosi = cos(by);
+        return Vector2(
+                x * cosi - y * sine,
+                x * sine + y * cosi);
     }
+
+    Vector2 orthogonal() const {
+		return Vector2(y, -x);
+	}
 
     Vector2 tangent() const {
         return Vector2(y, -x);
@@ -319,17 +437,41 @@ struct Vector2 {
         return Vector2(.floor(x), .floor(y));
     }
 
+    Vector2 ceil() const {
+        return Vector2(.ceil(x), .ceil(y));
+    }
+
+    Vector2 round() const {
+        return Vector2(.round(x), .round(y));
+    }
+
     Vector2 snapped(in Vector2 p_by) const {
         return Vector2(
             p_by.x != 0 ? .floor(x / p_by.x + 0.5) * p_by.x : x,
             p_by.y != 0 ? .floor(y / p_by.y + 0.5) * p_by.y : y
         );
     }
+
+    bool isEqualApprox(Vector2 other) const {
+        return isClose(x, other.x) && isClose(y, other.y);
+    }
+
+    Vector2 clamp(in Vector2 p_min, in Vector2 p_max) const {
+        return Vector2(.clamp(x, p_min.x, p_max.x), .clamp(y, p_min.y, p_max.y));
+    }
 }
 
-// TODO: replace this stub
+
+// ################## Vector2i ################################################ 
+
+
 struct Vector2i {
 @nogc nothrow:
+
+    enum Axis {
+		x,
+		y,
+	}
 
     union {
         struct {
@@ -376,12 +518,12 @@ struct Vector2i {
         this.y = b._opaque[1];
     }
 
-    ref godot_int opIndex(int axis) return {
-        return axis ? y : x;
+    ref godot_int opIndex(int idx) return {
+        return coord[idx];
     }
 
-    const(godot_int) opIndex(int axis) const {
-        return axis ? y : x;
+    const(godot_int) opIndex(int idx) const {
+        return coord[idx];
     }
 
     Vector2i opBinary(string op)(in Vector2i other) const
@@ -404,7 +546,7 @@ struct Vector2i {
 
     Vector2i opBinary(string op)(in godot_int scalar) const
     if (op == "*" || op == "/") {
-        Vector2 ret;
+        Vector2i ret;
         ret.x = mixin("x " ~ op ~ " scalar");
         ret.y = mixin("y " ~ op ~ " scalar");
         return ret;
@@ -423,7 +565,7 @@ struct Vector2i {
         y = mixin("y " ~ op ~ " scalar");
     }
 
-    int opCmp(in Vector2 other) const {
+    int opCmp(in Vector2i other) const {
         import std.algorithm.comparison;
         import std.range;
 
@@ -434,9 +576,21 @@ struct Vector2i {
         return Vector2(x, y);
     }
 
-    real_t aspect() const {
-        return width / cast(real_t) height;
-    }
+    Vector2i.Axis minAxisIndex() const {
+		return x < y ? Axis.x : Axis.y;
+	}
+
+	Vector2i.Axis maxAxisIndex() const {
+		return x < y ? Axis.y : Axis.x;
+	}
+
+	Vector2i min(in Vector2i p_vector2i) const {
+		return Vector2i(.min(x, p_vector2i.x), .min(y, p_vector2i.y));
+	}
+
+	Vector2i max(in Vector2i p_vector2i) const {
+		return Vector2i(.max(x, p_vector2i.x), .max(y, p_vector2i.y));
+	}
 
     real_t length() const {
         return cast(real_t) sqrt(cast(double) lengthSquared());
@@ -446,14 +600,27 @@ struct Vector2i {
         return (x * cast(int64_t) x) + (y * cast(int64_t) y);
     }
 
-    Vector2i abs() const {
-        import std.math : abs;
+    int64_t distanceSquaredTo(in Vector2i to) const {
+        return (to - this).lengthSquared();
+    }
 
+	double distanceTo(in Vector2i to) const {
+        return (to - this).length();
+    }
+
+    real_t aspect() const {
+        return width / cast(real_t) height;
+    }
+
+    Vector2i sign() const {
+        return Vector2i(sgn(x), sgn(y));
+    }
+
+    Vector2i abs() const {
         return Vector2i(.abs(x), .abs(y));
     }
 
     Vector2i clamp(in Vector2i p_min, in Vector2i p_max) const {
-        import std.algorithm.comparison : _clamp = clamp; // template looses priority to local symbol
-        return Vector2i(_clamp(x, p_min.x, p_max.x), _clamp(y, p_min.y, p_max.y));
+        return Vector2i(.clamp(x, p_min.x, p_max.x), .clamp(y, p_min.y, p_max.y));
     }
 }

--- a/src/godot/vector3.d
+++ b/src/godot/vector3.d
@@ -15,9 +15,14 @@ module godot.vector3;
 
 import godot.abi.core;
 import godot.abi.types;
+import godot.api.types;
 import godot.basis;
 import godot.string;
+import godot.math;
+import godot.vector2;
 
+
+import std.algorithm.comparison; // min, max
 import std.math;
 
 private bool isValidSwizzle(dstring s) {
@@ -113,12 +118,12 @@ struct Vector3 {
         this.z = b.z;
     }
 
-    const(real_t) opIndex(int p_axis) const {
-        return coord[p_axis];
+    const(real_t) opIndex(int axis) const {
+        return coord[axis];
     }
 
-    ref real_t opIndex(int p_axis) return {
-        return coord[p_axis];
+    ref real_t opIndex(int axis) return {
+        return coord[axis];
     }
 
     Vector3 opBinary(string op)(in Vector3 other) const
@@ -137,7 +142,7 @@ struct Vector3 {
         z = mixin("z " ~ op ~ "other.z");
     }
 
-    Vector3 opUnary(string op : "-")() {
+    Vector3 opUnary(string op : "-")() const {
         return Vector3(-x, -y, -z);
     }
 
@@ -165,10 +170,38 @@ struct Vector3 {
         z = mixin("z " ~ op ~ " scalar");
     }
 
+    Vector3i opCast(Vector3i)() const {
+        return Vector3i(x, y, z);
+    }
+
     int opCmp(in Vector3 other) const {
         import std.algorithm.comparison;
 
         return cmp(this.coord[], other.coord[]);
+    }
+
+    bool opEquals(in Vector3 other) const {
+        return x == other.x && y == other.y && z == other.z;
+    }
+
+    Vector3.Axis minAxisIndex() const {
+		return x < y ? (x < z ? Axis.x : Axis.z) : (y < z ? Axis.y : Axis.z);
+	}
+
+	Vector3.Axis maxAxisIndex() const {
+		return x < y ? (y < z ? Axis.z : Axis.y) : (x < z ? Axis.z : Axis.x);
+	}
+
+	Vector3 min(in Vector3 other) const {
+		return Vector3(.min(x, other.x), .min(y, other.y), .min(z, other.z));
+	}
+
+	Vector3 max(in Vector3 other) const {
+		return Vector3(.max(x, other.x), .max(y, other.y), .max(z, other.z));
+	}
+
+    void zero() { 
+        coord[] = 0;
     }
 
     Vector3 abs() const {
@@ -179,6 +212,55 @@ struct Vector3 {
         return Vector3(.ceil(x), .ceil(y), .ceil(z));
     }
 
+    Vector3 floor() const {
+        return Vector3(.floor(x), .floor(y), .floor(z));
+    }
+
+    Vector3 sign() const {
+        return Vector3(.sgn(x), .sgn(y), .sgn(z));
+    }
+
+    Vector3 round() const {
+        return Vector3(.round(x), .round(y), .round(z));
+    }
+
+    Vector3 clamp(in Vector3 min, in Vector3 max) const {
+        return Vector3(
+            .clamp(x, min.x, max.x),
+            .clamp(y, min.y, max.y),
+            .clamp(z, min.z, max.z),
+        );
+    }
+
+    Vector3 posmod(const real_t mod) const {
+        return Vector3(.fposmod(x, mod), .fposmod(y, mod), .fposmod(z, mod));
+    }
+
+    Vector3 posmodv(in Vector3 modv) const {
+        return Vector3(.fposmod(x, modv.x), .fposmod(y, modv.y), .fposmod(z, modv.z));
+    }
+
+    Vector3 project(in Vector3 to) const {
+        return to * (dot(to) / to.lengthSquared());
+    }
+
+    real_t angleTo(in Vector3 to) const {
+        return atan2(cross(to).length(), dot(to));
+    }
+
+    real_t signedAngleTo(in Vector3 to, in Vector3 axis) const {
+        Vector3 cross_to = cross(to);
+        real_t unsigned_angle = atan2(cross_to.length(), dot(to));
+        real_t sign = cross_to.dot(axis);
+        return (sign < 0) ? -unsigned_angle : unsigned_angle;
+    }
+
+    Vector3 directionTo(in Vector3 to) const {
+        Vector3 ret = Vector3(to.x - x, to.y - y, to.z - z);
+        ret.normalize();
+        return ret;
+    }
+
     Vector3 cross(in Vector3 b) const {
         return Vector3(
             (y * b.z) - (z * b.y),
@@ -187,31 +269,115 @@ struct Vector3 {
         );
     }
 
-    Vector3 linearInterpolate(in Vector3 p_b, real_t p_t) const {
+    Vector3 linearInterpolate(in Vector3 b, const real_t t) const {
         return Vector3(
-            x + (p_t * (p_b.x - x)),
-            y + (p_t * (p_b.y - y)),
-            z + (p_t * (p_b.z - z))
+            x + (t * (b.x - x)),
+            y + (t * (b.y - y)),
+            z + (t * (b.z - z))
         );
     }
 
     alias lerp = linearInterpolate;
 
-    Vector3 cubicInterpolate(in Vector3 b, in Vector3 pre_a, in Vector3 post_b, in real_t t) const {
-        Vector3 p0 = pre_a;
-        Vector3 p1 = this;
-        Vector3 p2 = b;
-        Vector3 p3 = post_b;
+    Vector3 slerp(in Vector3 to, const real_t weight) const {
+        // This method seems more complicated than it really is, since we write out
+        // the internals of some methods for efficiency (mainly, checking length).
+        real_t start_length_sq = lengthSquared();
+        real_t end_length_sq = to.lengthSquared();
+        if (start_length_sq == 0.0f || end_length_sq == 0.0f) {
+            // Zero length vectors have no angle, so the best we can do is either lerp or throw an error.
+            return lerp(to, weight);
+        }
+        Vector3 axis = cross(to);
+        real_t axis_length_sq = axis.lengthSquared();
+        if (axis_length_sq == 0.0f) {
+            // Colinear vectors have no rotation axis or angle between them, so the best we can do is lerp.
+            return lerp(to, weight);
+        }
+        axis /= sqrt(axis_length_sq);
+        real_t start_length = sqrt(start_length_sq);
+        real_t result_length = .lerp(start_length, .sqrt(end_length_sq), weight);
+        real_t angle = angleTo(to);
+        return rotated(axis, angle * weight) * (result_length / start_length);
+    }
 
+    Vector3 cubicInterpolate(in Vector3 b, in Vector3 pre_a, in Vector3 post_b, const real_t weight) const {
+        Vector3 res = this;
+        res.x = .cubicInterpolate(res.x, b.x, pre_a.x, post_b.x, weight);
+        res.y = .cubicInterpolate(res.y, b.y, pre_a.y, post_b.y, weight);
+        res.z = .cubicInterpolate(res.z, b.z, pre_a.z, post_b.z, weight);
+        return res;
+    }
+
+    Vector3 cubicInterpolateInTime(in Vector3 b, in Vector3 pre_a, in Vector3 post_b, const real_t weight, const real_t b_t, const real_t pre_a_t, const real_t post_b_t) const {
+        Vector3 res = this;
+        res.x = .cubicInterpolateInTime(res.x, b.x, pre_a.x, post_b.x, weight, b_t, pre_a_t, post_b_t);
+        res.y = .cubicInterpolateInTime(res.y, b.y, pre_a.y, post_b.y, weight, b_t, pre_a_t, post_b_t);
+        res.z = .cubicInterpolateInTime(res.z, b.z, pre_a.z, post_b.z, weight, b_t, pre_a_t, post_b_t);
+        return res;
+    }
+
+    Vector3 bezierInterpolate(in Vector3 control_1, in Vector3 control_2, in Vector3 end, const real_t t) const {
+        Vector3 res = this;
+
+        /* Formula from Wikipedia article on Bezier curves. */
+        real_t omt = (1.0 - t);
+        real_t omt2 = omt * omt;
+        real_t omt3 = omt2 * omt;
         real_t t2 = t * t;
         real_t t3 = t2 * t;
 
-        Vector3 ret;
-        ret = ((p1 * 2.0) +
-                (-p0 + p2) * t +
-                (p0 * 2.0 - p1 * 5.0 + p2 * 4 - p3) * t2 +
-                (-p0 + p1 * 3.0 - p2 * 3.0 + p3) * t3) * 0.5;
-        return ret;
+        return res * omt3 + control_1 * omt2 * t * 3.0 + control_2 * omt * t2 * 3.0 + end * t3;
+    }
+
+    Vector3 moveToward(in Vector3 to, const real_t delta) const {
+        Vector3 v = this;
+        Vector3 vd = to - v;
+        real_t len = vd.length();
+        if (len <= delta || len < CMP_EPSILON)
+            return to;
+        return (v + vd / len * delta);
+    }
+
+    Vector2 octahedronEncode() const {
+        Vector3 n = this;
+        n /= .abs(n.x) + .abs(n.y) + .abs(n.z);
+        Vector2 o;
+        if (n.z >= 0.0f) {
+            o.x = n.x;
+            o.y = n.y;
+        } else {
+            o.x = (1.0f - .abs(n.y)) * (n.x >= 0.0f ? 1.0f : -1.0f);
+            o.y = (1.0f - .abs(n.x)) * (n.y >= 0.0f ? 1.0f : -1.0f);
+        }
+        o.x = o.x * 0.5f + 0.5f;
+        o.y = o.y * 0.5f + 0.5f;
+        return o;
+    }
+
+    static Vector3 octahedronDecode(in Vector2 oct) {
+        Vector2 f = Vector2(oct.x * 2.0f - 1.0f, oct.y * 2.0f - 1.0f);
+        Vector3 n = Vector3(f.x, f.y, 1.0f - .abs(f.x) - .abs(f.y));
+        float t = .clamp(-n.z, 0.0f, 1.0f);
+        n.x += n.x >= 0 ? -t : t;
+        n.y += n.y >= 0 ? -t : t;
+        return n.normalized();
+    }
+
+    Vector2 octahedronTangentEncode(const float sign) const {
+        Vector2 res = octahedronEncode();
+        res.y = res.y * 0.5f + 0.5f;
+        res.y = sign >= 0.0f ? res.y : 1 - res.y;
+        return res;
+    }
+
+	static Vector3 octahedronTangentDecode(in Vector2 oct, float *sign) {
+        Vector2 oct_compressed = oct;
+        oct_compressed.y = oct_compressed.y * 2 - 1;
+        *sign = oct_compressed.y >= 0.0f ? 1.0f : -1.0f;
+        oct_compressed.y = .abs(oct_compressed.y);
+        Vector3 res = Vector3.octahedronDecode(oct_compressed);
+        return res;
     }
 
     real_t length() const {
@@ -230,20 +396,24 @@ struct Vector3 {
         return x2 + y2 + z2;
     }
 
-    real_t distanceSquaredTo(in Vector3 b) const {
-        return (b - this).length();
+    real_t distanceSquaredTo(in Vector3 other) const {
+        return (other - this).length();
     }
 
-    real_t distanceTo(in Vector3 b) const {
-        return (b - this).lengthSquared();
+    real_t distanceTo(in Vector3 other) const {
+        return (other - this).lengthSquared();
     }
 
-    real_t dot(in Vector3 b) const {
-        return x * b.x + y * b.y + z * b.z;
+    real_t dot(in Vector3 other) const {
+        return x * other.x + y * other.y + z * other.z;
     }
 
-    Vector3 floor() const {
-        return Vector3(.floor(x), .floor(y), .floor(z));
+    Basis outer(in Vector3 other) const {
+        Basis basis;
+        basis.rows[0] = Vector3(x * other.x, x * other.y, x * other.z);
+        basis.rows[1] = Vector3(y * other.x, y * other.y, y * other.z);
+        basis.rows[2] = Vector3(z * other.x, z * other.y, z * other.z);
+        return basis;
     }
 
     Vector3 inverse() const {
@@ -259,10 +429,11 @@ struct Vector3 {
     }
 
     void normalize() {
-        real_t l = length();
-        if (l == 0) {
+        real_t lensq = lengthSquared();
+        if (lensq == 0) {
             x = y = z = 0;
         } else {
+            real_t l = sqrt(lensq);
             x /= l;
             y /= l;
             z /= l;
@@ -275,33 +446,77 @@ struct Vector3 {
         return v;
     }
 
-    Vector3 reflect(in Vector3 by) const {
-        return by - this * this.dot(by) * 2.0;
+    bool isNormalized() const {
+        // use length_squared() instead of length() to avoid sqrt(), makes it more stringent.
+        return isClose(lengthSquared(), 1, UNIT_EPSILON);
     }
 
-    Vector3 rotated(in Vector3 axis, in real_t phi) const {
+    Vector3 limitLength(in real_t newLength = 1.0) const {
+        const real_t curLength = length();
         Vector3 v = this;
-        v.rotate(axis, phi);
+        if (curLength > 0 && newLength < curLength) {
+            v /= curLength;
+            v *= newLength;
+        }
+
         return v;
     }
 
-    void rotate(in Vector3 axis, in real_t phi) {
-        this = Basis(axis, phi).xform(this);
+    Vector3 rotated(in Vector3 axis, in real_t angle) const {
+        Vector3 v = this;
+        v.rotate(axis, angle);
+        return v;
     }
 
-    Vector3 slide(in Vector3 by) const {
-        return by - this * this.dot(by);
+    void rotate(in Vector3 axis, in real_t angle) {
+        this = Basis(axis, angle).xform(this);
     }
 
+    // slide returns the component of the vector along the given plane, specified by its normal vector.
+    Vector3 slide(in Vector3 normal) const {
+        return this - normal * this.dot(normal);
+    }
+
+    Vector3 bounce(in Vector3 normal) const {
+        return -reflect(normal);
+    }
+
+	Vector3 reflect(in Vector3 normal) const {
+        return 2.0 * normal * this.dot(normal) - this;
+    }
+
+    // Superbelko: should we keep it for convenience?
+    deprecated("use snap(Vector3)")
     void snap(real_t step) {
-        foreach (ref v; coord)
-            v = (step != 0) ? (.floor(v / step + 0.5) * step) : v;
+        snap(Vector3(step, step, step));
     }
 
+    void snap(Vector3 step) {
+        static foreach (i; 0..coord.length)
+            coord[i] = .snapped(coord[i], step[i]);
+    }
+
+    deprecated("use snapped(Vector3)")
     Vector3 snapped(in real_t step) const {
+        Vector3 v = this;
+        v.snap(Vector3(step, step, step));
+        return v;
+    }
+
+    Vector3 snapped(in Vector3 step) const {
         Vector3 v = this;
         v.snap(step);
         return v;
+    }
+
+    bool isEqualApprox(in Vector3 other) const {
+        import std.math : isClose;
+        return isClose(x, other.x) && isClose(y, other.y) && isClose(z, other.z);
+    }
+
+    bool isZeroApprox() const {
+        import std.math : isClose;
+        return isClose(x, 0) && isClose(y, 0) && isClose(z, 0);
     }
 }
 
@@ -355,12 +570,12 @@ struct Vector3i {
         this.z = b._opaque[2];
     }
 
-    const(godot_int) opIndex(int p_axis) const {
-        return coord[p_axis];
+    const(godot_int) opIndex(int axis) const {
+        return coord[axis];
     }
 
-    ref godot_int opIndex(int p_axis) return {
-        return coord[p_axis];
+    ref godot_int opIndex(int axis) return {
+        return coord[axis];
     }
 
     Vector3i opBinary(string op)(in Vector3i other) const
@@ -413,6 +628,10 @@ struct Vector3i {
         return cmp(this.coord[], other.coord[]);
     }
 
+    bool opEquals(in Vector3i other) const {
+        return coord[] == other.coord[];
+    }
+
     int maxAxis() const {
         return (x < y) ? (y < z ? 2 : 1) : (x < z ? 2 : 0);
     }
@@ -421,20 +640,36 @@ struct Vector3i {
         return (x < y) ? (x < z ? 0 : 2) : (y < z ? 1 : 2);
     }
 
-    Vector3i abs() const {
-        return Vector3i(.abs(x), .abs(y), .abs(z));
+    Vector3i.Axis minAxisIndex() const {
+		return x < y ? (x < z ? Axis.x : Axis.z) : (y < z ? Axis.y : Axis.z);
+	}
+
+	Vector3i.Axis maxAxisIndex() const {
+		return x < y ? (y < z ? Axis.z : Axis.y) : (x < z ? Axis.z : Axis.x);
+	}
+
+    Vector3i min(in Vector3i other) const {
+        return Vector3i(.min(x, other.x), .min(y, other.y), .min(z, other.z));
     }
+
+    Vector3i max(in Vector3i other) const {
+		return Vector3i(.max(x, other.x), .max(y, other.y), .max(z, other.z));
+	}
 
     void zero() {
         coord[] = 0;
     }
 
-    int64_t length_squared() const {
+    int64_t lengthSquared() const {
         return (x * cast(int64_t) x) + (y * cast(int64_t) y) + (z * cast(int64_t) z);
     }
 
     double length() const {
-        return sqrt(cast(double) length_squared());
+        return sqrt(cast(double) lengthSquared());
+    }
+
+    Vector3i abs() const {
+        return Vector3i(.abs(x), .abs(y), .abs(z));
     }
 
     Vector3i sign() const {
@@ -442,10 +677,8 @@ struct Vector3i {
         return Vector3i(sgn(x), sgn(y), sgn(z));
     }
 
-    Vector3i clamp(in Vector3i p_min, in Vector3i p_max) const {
-        import std.algorithm.comparison : _clamp = clamp; // template looses priority to local symbol
-        return Vector3i(_clamp(x, p_min.x, p_max.x), _clamp(y, p_min.y, p_max.y), _clamp(z, p_min.z, p_max
-                .z));
+    Vector3i clamp(in Vector3i min, in Vector3i max) const {
+        return Vector3i(.clamp(x, min.x, max.x), .clamp(y, min.y, max.y), .clamp(z, min.z, max.z));
     }
 
     Vector3 opCast(Vector3)() const {


### PR DESCRIPTION
Until now core types like Vector or Basis was consist of a mix Godot 3 and Godot 4.0 beta API, this update makes it in line with latest Godot version (4.3 dev2 at the moment of writing).

For most of it all removed functions should have deprecation warning with instructions on how to update.

Due to bindings is not fully covered with @nogc some functions are versioned out.

Additionally, for named arguments support most parameters was adjusted to make more sense.
There still the cases where similar functions may have inconsistent naming, e.g. weight/t parameter for parametric functions.

There is still some unclear questions about whether to use out parameter instead or pointers, so it is kept as is to let the caller clearly see that the function modifies parameter, i.e.

```c++
Vector3 distance;
frobThis(normal, d, &distance); // <- writes distance
```

(ignore the intersectRay for now, I think there was some wtf error)