### PR TITLE
fix compiler error on single-letter variables

### DIFF
--- a/src/godot/api/wrap.d
+++ b/src/godot/api/wrap.d
@@ -765,7 +765,10 @@ struct VirtualMethodsHelper(T) {
     static bool matchesNamingConv(string name)() {
         import std.uni : isAlphaNum;
 
-        return name[0] == '_' && name[1].isAlphaNum;
+        static if (name.length > 1)
+            return name[0] == '_' && name[1].isAlphaNum;
+        else
+            return false;
     }
     import std.meta;
     static bool isFunc(alias member)() {


### PR DESCRIPTION
e.g. creating `float t;` inside my `class MyComponent : GodotScript!Node`

the awkward syntax with `static if` is needed since this is a compile time argument, which would still evaluate `name[1]` and causing a compile time error.