### PR TITLE
Fix some cases where Rename hasn't picked up by class registration

### DIFF
--- a/src/godot/api/register.d
+++ b/src/godot/api/register.d
@@ -620,12 +620,17 @@ void register(T)(GDExtensionClassLibraryPtr lib) if (is(T == class)) {
             alias udas = getUDAs!(mixin("T." ~ pName), Singleton);
             enum Singleton uda = is(udas[0]) ? Singleton.init : udas[0];
 
-            StringName snPropName = StringName(pName);
+            alias renameAttr = getUDAs!(mixin("T." ~ pName), Rename);
+            enum Rename renamed = is(renameAttr[0]) ? Rename.init : renameAttr[0];
+            static if (renamed.name)
+                StringName snPropName = StringName(renamed.name);
+            else
+                StringName snPropName = StringName(pName);
 
             storageField = memnew!P;
             
             import godot.engine;
-            Engine.registerSingleton(snPropName, storageField);
+            Engine.registerSingleton(snPropName, storageField._godot_base);
         }
     }
 
@@ -669,7 +674,13 @@ void unregister(T)(GDExtensionClassLibraryPtr lib) if (is(T == class)) {
             alias udas = getUDAs!(mixin("T." ~ pName), Singleton);
             enum Singleton uda = is(udas[0]) ? Singleton.init : udas[0];
 
-            StringName snPropName = StringName(pName);
+            alias renameAttr = getUDAs!(mixin("T." ~ pName), Rename);
+            enum Rename renamed = is(renameAttr[0]) ? Rename.init : renameAttr[0];
+            static if (renamed.name)
+                StringName snPropName = StringName(renamed.name);
+            else
+                StringName snPropName = StringName(pName);
+                
             Engine.unregisterSingleton(snPropName);
             memdelete(storageField);
         }}

--- a/src/godot/api/udas.d
+++ b/src/godot/api/udas.d
@@ -214,10 +214,10 @@ struct OnInit {
         && extends!(GodotClass!Owner, Node);
 
     static OnInit makeDefault(R, Owner)() {
-        import godot.reference, godot.node, godot.resource;
+        import godot.refcounted, godot.node, godot.resource;
 
         OnInit ret;
-        static if (is(GodotClass!R : Reference))
+        static if (is(GodotClass!R : RefCounted))
             ret.autoDelete = false; // ref-counted
         static if (canAddChild!(R, Owner)) {
             ret.autoAddChild = true;

--- a/src/godot/api/wrap.d
+++ b/src/godot/api/wrap.d
@@ -635,7 +635,16 @@ package(godot) PropertyInfo makePropertyInfo(alias T, string Name)() {
     else
         String snHint = String();
 
-    static if (Variant.variantTypeOf!T == VariantType.object) {
+    // this will probably require same fix for other conainers like TypedArray
+    alias typeRenameAttr = getUDAs!(NonRef!T, Rename); // Ref itself has no attributes
+    static if (typeRenameAttr.length)
+        enum Rename typeRenamed = typeRenameAttr[0];
+    else
+        enum Rename typeRenamed = Rename.init;
+    static if (typeRenamed.name) {
+        StringName snClassName = StringName(typeRenamed.name);
+    }
+    else static if (Variant.variantTypeOf!T == VariantType.object) {
         static if (is(T == GodotObject))
             StringName snClassName = StringName("Object");
         else static if (is(T == Ref!U, U))


### PR DESCRIPTION
Fix #177 #178

Singleton registration now uses `object._godot_base` since there is no guarantee that user classes will have `alias this`, and add some missing `@Rename` cases.