### PR TITLE
Allow D methods to register as signals, fix CI

### DIFF
--- a/.github/workflows/d.yml
+++ b/.github/workflows/d.yml
@@ -22,10 +22,15 @@ jobs:
         flavor: ['structs', 'classes']
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: dlang-community/setup-dlang@4c99aa991ce7d19dd3064de0a4f2f6b2f152e2d7
+    - uses: actions/checkout@v4
+    - uses: dlang-community/setup-dlang@v1
       with:
         compiler: ldc-latest
+    - uses: dsaltares/fetch-gh-release-asset@master
+      with:
+        repo: 'godotengine/godot'
+        version: 'tags/4.2.2-stable'
+        file: 'Godot_v4.2.2-stable_linux.x86_64.zip'
         
     - name: 'Godot doesnt works without X server'
       run: export DISPLAY=:99
@@ -33,10 +38,9 @@ jobs:
 
     - name: 'Get godot & dump api'
       run: |
-        curl -O https://downloads.tuxfamily.org/godotengine/4.2/beta3/Godot_v4.2-beta3_linux.x86_64.zip
         sudo apt-get install -y unzip
-        unzip Godot_v4.2-beta3_linux.x86_64.zip
-        export GDEXE=./Godot_v4.2-beta3_linux.x86_64
+        unzip Godot_v4.2.2-stable_linux.x86_64.zip
+        export GDEXE=./Godot_v4.2.2-stable_linux.x86_64
         echo "GDEXE=$GDEXE" >> $GITHUB_ENV
         $GDEXE --headless --dump-extension-api
       

--- a/examples/test/project/main.gd
+++ b/examples/test/project/main.gd
@@ -1,5 +1,6 @@
 extends Node
 
+var anotherSignalOk: bool
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
@@ -34,3 +35,12 @@ func _process(delta):
 func _on_label_send_message(arg0):
 	print("send_message received: ", arg0)
 	$Panel/Label/One/Looooong/Incredibly/Unbroken/Node/Path/Label2.set_text(arg0)
+
+
+func _on_label_another_signal(v):
+	assert(v == 42)
+	print("another signal called with value: ", v)
+	anotherSignalOk = true
+
+func _exit_tree():
+	assert(anotherSignalOk, "another signal was never called")

--- a/examples/test/src/example.d
+++ b/examples/test/src/example.d
@@ -145,6 +145,11 @@ class Test : GodotScript!Label {
     @Signal @Rename("send_message")
     static void function(String message) sendMessage;
 
+    /// Another way to define signal by using regular method, can be useful for cleaner API designs
+    @Signal void anotherSignal(int v) {
+        emitSignal("another_signal", v);
+    }
+
 version(USE_CLASSES) {
 
     @Method
@@ -175,6 +180,9 @@ version(USE_CLASSES) {
         emitSignal("send_message", "Some text sent by a signal");
         // alternative syntax using types instead of plain string
         emit!sendMessage("Some text sent by a signal");
+        // anotherSignal can be invoked as above, 
+        // or as in this case by just calling D function that emits signal
+        anotherSignal(42);
 
         // internal inheritance test, _godot_base is a struct serving as a base interface.
         // this is an implementation detail, users don't need to use it at all.


### PR DESCRIPTION
- Let's you put `@Signal` on D methods, but not with `@Method`.

- [CI] github actions upgraded to fix deprecation warnings, switched godot download location due to availability issues.