### PR TITLE
TypedDictionary experimental support

### DIFF
--- a/examples/test/project/main.gd
+++ b/examples/test/project/main.gd
@@ -25,6 +25,20 @@ func _ready():
 	# since this is an Object it is up to you to release it when you've done with it
 	# don't forget to free it when it is no longer in use
 	base.free()
+
+	# TestD class extends Label which is attached to panel, weird but ok
+	var test_class = $Panel/Label as TestD
+	assert(test_class, "TestD object is null: something wrong with node layout or bindings")
+	
+	# Test typed array (added in 4.2)
+	if Engine.get_version_info().hex >= 0x040200:
+		var arr = test_class.get_typed_array()
+		assert(arr[1] == 7)
+	
+	# Test typed dictionary (added in 4.4)
+	if Engine.get_version_info().hex >= 0x040400:
+		var dict = test_class.get_typed_dict()
+		assert(dict[42] == "Hello", "TypedDictionary[42] == Hello: failed")
 	
 	# Virtual functions test for Godot 4.3+
 	if Engine.get_version_info().hex >= 0x040300:

--- a/examples/test/src/example.d
+++ b/examples/test/src/example.d
@@ -157,6 +157,20 @@ class Test : GodotScript!Label {
     @Signal
     static void function(int) signalWithUnnamedParameter;
 
+    // method returning TypedArray (introduced in Godot 4.2)
+    static if (godotversion.VERSION_MINOR > 1) {
+        @Method TypedArray!(int) getTypedArray() {
+            return TypedArray!int.make(42, 7, 1);
+        }
+    }
+
+    // method returning TypedDictionary (introduced in Godot 4.3)
+    static if (godotversion.VERSION_MINOR > 2) {
+        @Method TypedDictionary!(int, String) getTypedDict() {
+            return TypedDictionary!(int, String).make(42, "Hello");
+        }
+    }
+
 version(USE_CLASSES) {
 
     @Method

--- a/modules/tools/generator/classes.d
+++ b/modules/tools/generator/classes.d
@@ -133,6 +133,13 @@ final class GodotClass {
             return;
         if (u.isTypedArray)
             u = u.arrayType;
+        if (u.isTypedDictionary) {
+            // well, this is a special case...
+            auto p = u.dictTypePair;
+            u = p.left;
+            if (!used_classes.canFind(p.right))
+                used_classes ~= p.right;
+        }
         if (!used_classes.canFind(u))
             used_classes ~= u;
     }
@@ -331,6 +338,13 @@ public import godot.classdb;`;
             className ~= "_Bind";
         ret ~= "/**\n" ~ ddoc ~ "\n*/\n";
         ret ~= "@GodotBaseClass ";
+        if (!instanciable) {
+            // FIXME: it turns out this currently simply doesn't works, need fixing allocations like in displayserver.d:2807 (_new factory method?)
+            //if (settings.useClasses && !(isBuiltinClass || name.isCoreType))
+            //    ret ~= "abstract ";
+            //else
+                ret ~= "@GodotAbstract ";
+        }
         if (settings.useClasses)
             ret ~= (isBuiltinClass ? "struct" : "class");
         else

--- a/src/godot/abi/gdextension_binding.d
+++ b/src/godot/abi/gdextension_binding.d
@@ -264,7 +264,9 @@ alias GDExtensionClassCreateInstance2 = GDExtensionObjectPtr function(void* p_cl
 alias GDExtensionClassFreeInstance = void function(void* p_class_userdata, GDExtensionClassInstancePtr p_instance);
 alias GDExtensionClassRecreateInstance = GDExtensionClassInstancePtr function(void* p_class_userdata, GDExtensionObjectPtr p_object);
 alias GDExtensionClassGetVirtual = GDExtensionClassCallVirtual function(void* p_class_userdata, GDExtensionConstStringNamePtr p_name);
+alias GDExtensionClassGetVirtual2 = GDExtensionClassCallVirtual function(void* p_class_userdata, GDExtensionConstStringNamePtr p_name, uint32_t p_hash);
 alias GDExtensionClassGetVirtualCallData = void * function(void* p_class_userdata, GDExtensionConstStringNamePtr p_name);
+alias GDExtensionClassGetVirtualCallData2 = void * function(void* p_class_userdata, GDExtensionConstStringNamePtr p_name, uint32_t p_hash);
 alias GDExtensionClassCallVirtualWithData = void function(GDExtensionClassInstancePtr p_instance, GDExtensionConstStringNamePtr p_name, void* p_virtual_call_userdata, const(GDExtensionConstTypePtr)* p_args, GDExtensionTypePtr r_ret);
 
 // Deprecated. Use GDExtensionClassCreationInfo3 instead.
@@ -351,6 +353,7 @@ struct GDExtensionClassCreationInfo4
     GDExtensionBool is_abstract;
     GDExtensionBool is_exposed;
     GDExtensionBool is_runtime;
+    GDExtensionConstStringPtr icon_path;
     GDExtensionClassSet set_func;
     GDExtensionClassGet get_func;
     GDExtensionClassGetPropertyList get_property_list_func;
@@ -365,8 +368,8 @@ struct GDExtensionClassCreationInfo4
     GDExtensionClassCreateInstance2 create_instance_func;
     GDExtensionClassFreeInstance free_instance_func;
     GDExtensionClassRecreateInstance recreate_instance_func;
-    GDExtensionClassGetVirtual get_virtual_func;
-    GDExtensionClassGetVirtualCallData get_virtual_call_data_func;
+    GDExtensionClassGetVirtual2 get_virtual_func;
+    GDExtensionClassGetVirtualCallData2 get_virtual_call_data_func;
     GDExtensionClassCallVirtualWithData call_virtual_with_data_func;
     void* class_userdata;
 }

--- a/src/godot/api/register.d
+++ b/src/godot/api/register.d
@@ -357,6 +357,13 @@ void register(T)(GDExtensionClassLibraryPtr lib) if (is(T == class)) {
         return VirtualMethodsHelper!T.findVCall(p_name);
     }
 
+    extern (C) static GDExtensionClassCallVirtual getVirtualFn2(void* p_userdata, const GDExtensionStringNamePtr p_name, uint p_hash) {
+        return getVirtualFn(p_userdata, p_name);
+    }
+
+    static if (isGodot44orNewer)
+    class_info.get_virtual_func = &getVirtualFn2;
+    else
     class_info.get_virtual_func = &getVirtualFn;
 
     StringName snClass = StringName(name);

--- a/src/godot/api/wrap.d
+++ b/src/godot/api/wrap.d
@@ -632,6 +632,8 @@ package(godot) PropertyInfo makePropertyInfo(alias T, string Name)() {
         String snHint = String(makeTypeHint!T);
     else static if (extends!(T, Node) || extends!(T, Resource))
         String snHint = T.stringof;
+    else static if (is(T == TypedDictionary!(K,V), K, V))
+        String snHint = String(makeTypeHint!T);
     else
         String snHint = String();
 
@@ -656,6 +658,8 @@ package(godot) PropertyInfo makePropertyInfo(alias T, string Name)() {
     }
     else {
         static if (is(T == TypedArray!U, U)) // typed array has no class name but a hint
+            StringName snClassName = stringName();
+        else static if (is(T == TypedDictionary!(K,V), K, V)) // typed dictionary has no class name but a hint
             StringName snClassName = stringName();
         else static if (is(T == PackedArray!U, U))
             StringName snClassName = StringName(T.InternalName);
@@ -698,7 +702,7 @@ package(godot) template makeTypeHint(alias T) {
     }
     else static if (Variant.variantTypeOf!T != VariantType.nil) {
         string makeTypeHint = (cast(int) Variant.variantTypeOf!T).stringof 
-            ~ "/" ~ U.stringof;
+            ~ "/" ~ T.stringof;
     }
     else 
         string makeTypeHint = null;

--- a/src/godot/variant.d
+++ b/src/godot/variant.d
@@ -309,6 +309,11 @@ struct Variant {
         return T(as!Array);
     }
 
+    /// 
+    T as(T)() const if (is(T : TypedDictionary!(K,V), K,V)) {
+        return T(as!Dictionary);
+    }
+
     T as(T : void*)() {
         return cast(T)&_godot_variant;
     }
@@ -415,6 +420,9 @@ struct Variant {
         } else static if (is(T == TypedArray!U, U)) {
             // FIXME: it is supposed to be already compatible because of TypedArray's alias this
             alias conversionToGodot = (ref T t) => t._array; 
+        } else static if (is(T == TypedDictionary!(K,V), K, V)) {
+            // FIXME: it is supposed to be already compatible because of TypedDictionary alias this
+            alias conversionToGodot = (ref T t) => t._dictionary; 
         } else static if (hasInternalFrom!T)
             alias conversionToGodot = internalFrom!T;
         else
@@ -484,6 +492,9 @@ struct Variant {
                 // FIXME: this should already work because TypedArray has alias to Array which is compatible
                 static if (is(T == TypedArray!U, U))
                   enum Type variantTypeOf = Type.array; 
+                // FIXME: this should already work because TypedDictionary has alias to Array which is compatible
+                else static if (is(T == TypedDictionary!(K,V), K, V))
+                  enum Type variantTypeOf = Type.dictionary; 
                 else
                   enum Type variantTypeOf = Type.nil;
             }
@@ -494,6 +505,7 @@ struct Variant {
             enum Type variantTypeOf = Type.nil; // so the template always returns a Type
     }
     static assert (variantTypeOf!(TypedArray!int) == VariantType.array);
+    static assert (variantTypeOf!(TypedDictionary!(int, int)) == VariantType.dictionary);
 
     /// 
     R as(R)() const 


### PR DESCRIPTION
Note that this update changes Dictionary to rely on generated bindings rather than limited gdextension_* interface functions.
This means Dictionary destructor now requires to do null check and other such things.