### PR TITLE
Api AutoPull

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -31,8 +31,23 @@ configuration "classes" {
 	versions "USE_CLASSES"
 }
 
-preBuildCommands "if [ ! -d \"classes/\" ]; then echo \"ERROR: 'classes' dir not found, did you forgot to generate bindings?\" && exit 1; fi" platform="posix"
-preBuildCommands "if not exist \"classes\\\" ( echo ERROR: 'classes' dir not found, did you forgot to generate bindings? & exit 1 )" platform="windows"
+preBuildCommands "\
+	if [ ! -d \"classes/\" ]; then \
+		if [ ! -d \"extension_api.json\" ]; then \
+			echo \"             Downloading extension_api.json for bindings...\"; \
+			wget -O extension_api.json https://raw.githubusercontent.com/godotengine/godot-cpp/refs/heads/4.5/gdextension/extension_api.json; \
+		fi; \
+		dub run godot-dlang:generator -- -j extension_api.json -o; \
+	fi" platform="posix"
+
+preBuildCommands "\
+	if not exist \"classes\\\" ( \
+		if not exist \"extension_api.json\" ( \
+			echo              Downloading extension_api.json for bindings... && \
+			curl https://raw.githubusercontent.com/godotengine/godot-cpp/refs/heads/4.5/gdextension/extension_api.json -o extension_api.json \
+		) && \
+		dub run godot-dlang:generator -- -j extension_api.json -o \
+	)" platform="windows"
 // preBuildCommands "If (-not (Test-Path classes) ) { Write-Host \"No generated 'classes' dir found, did you forgot to generate bindings?\" -f Red ; exit 1 }" platform="windows"
 
 subPackage {


### PR DESCRIPTION
This both auto builds classes (if missing) from a local extension_api.json file, and if said file is missing, will auto download it from the official github repository. Dropping a dumped copy from a specific godot build while having no classes file included will auto generate bindings upon trying to build a project.

Adding an extra note, the repository is hard linked to a specific build (seems reasonable as newer builds may have incompatible generations and should only auto pull known working builds).

This is a feature request mostly because someone starting off with the latest tooling and no prior setup should have a fairly straight forward experience like other dub packages. Pull the library, write your code, invoke build and it just works itself out to generate your thing. This accomplishes that task.