### PR TITLE
Add subclass instantiation tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ lib/
 *.dll
 *.exe
 *.pdb
+*.dylib
 
 # Linux Binaries
 generator

--- a/examples/test/project/godot-dlang_test.gdextension
+++ b/examples/test/project/godot-dlang_test.gdextension
@@ -6,5 +6,6 @@ compatibility_minimum = 4.1
 [libraries]
 
 linux.64 = "libgodot-dlang_test.so"
+macos = "libgodot-dlang_test.dylib"
 windows.64 = "godot-dlang_test.dll"
 web = "libgodot-dlang_test.so"

--- a/examples/test/src/example.d
+++ b/examples/test/src/example.d
@@ -538,6 +538,22 @@ version(USE_CLASSES) {
                 assert(!(o > this));
         }
 
+        // test instantiation of D classes
+        {
+            SomeConcreteClass a = memnew!SomeConcreteClass;
+            scope(exit) memdelete(a);
+            SomeConcreteSubClass b = memnew!SomeConcreteSubClass;
+            scope(exit) memdelete(b);
+
+            print("Calling doSomething on SomeConcreteClass...");
+            a.doSomething();
+            assert(a.foo == 42);
+
+            print("Calling doSomething on SomeConcreteSubClass...");
+            b.doSomething();
+            assert(b.foo == 64);
+        }
+
         // test static method call
         {
             import godot.image;
@@ -638,6 +654,15 @@ class SomeConcreteClass : SomeBaseClass {
 }
 
 
+class SomeConcreteSubClass : SomeConcreteClass {
+    @Method
+    override void doSomething() {
+        foo = 64; // test expects it to be 64
+        print("i'm a subclass of concrete class");
+    }
+}
+
+
 class TestVirtualMethod : GodotScript!GodotObject {
 
     import godot.apiinfo;
@@ -680,5 +705,6 @@ mixin GodotNativeLibrary!(
 
     SomeBaseClass,
     SomeConcreteClass,
+    SomeConcreteSubClass,
     TestVirtualMethod
 );


### PR DESCRIPTION
Add tests for 600cf08 (part of #227), which fixed a bug where in `USE_CLASSES` mode, the instantiation (e.g. through `memnew!T`) of a D class that `extendsGodotBaseClass` would instead create an instance of the first non-Godot class (whatever one directly extends `GodotScript`) in `T`'s type-hierachy, rather than `T` itself. e.g. given `A : GodotScript!Node`, and `B : A`, `memnew!A` creates `A`, but `memnew!B` also creates `A`.

It's unclear exactly why this is, but something about passing a extended-from-D type (instead of the actual Godot base) into `gdextension_interface_classdb_construct_object` was causing issues.